### PR TITLE
Extend timeout for first test in chunk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/Installer.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Installer.kt
@@ -12,12 +12,16 @@ import java.util.concurrent.TimeUnit
 class Installer(private val adbDevice: AdbDevice, private val processRunner: ProcessRunner = ProcessRunner()) {
 
     suspend fun ensureTestPackageInstalled(args: Args, testChunk: TestChunk) {
-        val testPackage = testChunk.testModuleInfo.moduleInfo.apkPackage.value
-        if (adbDevice.installedPackages.contains(testPackage)) {
-            adbDevice.log("Packaged installed, package: $testPackage")
+        if (isInstalled(testChunk)) {
+            adbDevice.log("Package installed, package: ${testChunk.testModuleInfo.moduleInfo.apkPackage.value}")
         } else {
             installModuleApks(testChunk.testModuleInfo, args)
         }
+    }
+
+    fun isInstalled(testChunk: TestChunk) : Boolean {
+        val testPackage = testChunk.testModuleInfo.moduleInfo.apkPackage.value
+        return adbDevice.installedPackages.contains(testPackage)
     }
 
     private suspend fun installModuleApks(testModuleInfo: TestModuleInfo, args: Args) {

--- a/torque-core/src/main/kotlin/com/workday/torque/Installer.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Installer.kt
@@ -12,14 +12,14 @@ import java.util.concurrent.TimeUnit
 class Installer(private val adbDevice: AdbDevice, private val processRunner: ProcessRunner = ProcessRunner()) {
 
     suspend fun ensureTestPackageInstalled(args: Args, testChunk: TestChunk) {
-        if (isInstalled(testChunk)) {
+        if (isChunkApkInstalled(testChunk)) {
             adbDevice.log("Package installed, package: ${testChunk.testModuleInfo.moduleInfo.apkPackage.value}")
         } else {
             installModuleApks(testChunk.testModuleInfo, args)
         }
     }
 
-    fun isInstalled(testChunk: TestChunk) : Boolean {
+    fun isChunkApkInstalled(testChunk: TestChunk) : Boolean {
         val testPackage = testChunk.testModuleInfo.moduleInfo.apkPackage.value
         return adbDevice.installedPackages.contains(testPackage)
     }

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -96,7 +96,7 @@ class TestRunFactory {
 
     private fun getTimeoutMillis(args: Args, installer: Installer, testChunk: TestChunk): Long {
         val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * args.retriesPerChunk
-        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * args.retriesInstallPerApk
+        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * args.retriesPerChunk * args.retriesInstallPerApk
 
         return if (installer.isChunkApkInstalled(testChunk))
             chunkTimeOutWithRetries

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -4,9 +4,16 @@ import com.linkedin.dex.parser.TestMethod
 import com.workday.torque.pooling.TestChunk
 import com.workday.torque.pooling.TestPool
 import io.reactivex.Single
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asSingle
 import kotlinx.coroutines.rx2.await
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.TimeUnit
 
 class TestRunFactory {
@@ -91,7 +98,7 @@ class TestRunFactory {
         val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * args.retriesPerChunk
         val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * args.retriesInstallPerApk
 
-        return if (installer.isInstalled(testChunk))
+        return if (installer.isChunkApkInstalled(testChunk))
             chunkTimeOutWithRetries
         else
             chunkTimeOutWithRetries + installTimeOutWithRetries

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -33,7 +33,7 @@ class TestRunFactory {
             testChunkRunner: TestChunkRunner = TestChunkRunner(adbDevice, logcatFileIO, installer)
     ): Single<AdbDeviceTestSession> {
         val testSession = AdbDeviceTestSession(adbDevice = adbDevice,
-                logcatFile = logcatFileIO.fullLogcatFile)
+                                               logcatFile = logcatFileIO.fullLogcatFile)
         return GlobalScope.async(
                 context = Dispatchers.Default,
                 start = CoroutineStart.DEFAULT,
@@ -60,9 +60,9 @@ class TestRunFactory {
                     }
 
                     adbDevice.log("Device Test Session complete, " +
-                            "${testSession.passedCount} passed, " +
-                            "${testSession.failedCount} failed, took " +
-                            "${testSession.durationMillis.millisToHoursMinutesSeconds()}."
+                                "${testSession.passedCount} passed, " +
+                                "${testSession.failedCount} failed, took " +
+                                "${testSession.durationMillis.millisToHoursMinutesSeconds()}."
                     )
 
                     testSession
@@ -98,10 +98,12 @@ class TestRunFactory {
         val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * args.retriesPerChunk
         val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * args.retriesPerChunk * args.retriesInstallPerApk
 
-        return if (installer.isChunkApkInstalled(testChunk))
+        return if (installer.isChunkApkInstalled(testChunk)) {
             chunkTimeOutWithRetries
-        else
+        }
+        else {
             chunkTimeOutWithRetries + installTimeOutWithRetries
+        }
     }
 
 
@@ -155,9 +157,9 @@ class TestRunFactory {
                     .map { TestDetails(it.className, it.testName) }
                     .forEach { testDetails: TestDetails ->
                         filePuller.pullTestFolder(args.testFilesPullDeviceDirectory,
-                                args.testFilesPullHostDirectory,
-                                testDetails,
-                                pullFileTimeout).await()
+                                                  args.testFilesPullHostDirectory,
+                                                  testDetails,
+                                                  pullFileTimeout).await()
                     }
         }
     }

--- a/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
@@ -1,6 +1,8 @@
 package com.workday.torque
 
+import com.workday.torque.pooling.ModuleInfo
 import com.workday.torque.pooling.TestChunk
+import com.workday.torque.pooling.TestModuleInfo
 import com.workday.torque.pooling.TestPool
 import io.mockk.Ordering
 import io.mockk.coEvery

--- a/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
@@ -2,7 +2,11 @@ package com.workday.torque
 
 import com.workday.torque.pooling.TestChunk
 import com.workday.torque.pooling.TestPool
-import io.mockk.*
+import io.mockk.Ordering
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import io.reactivex.Completable
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context

--- a/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
@@ -1,14 +1,8 @@
 package com.workday.torque
 
-import com.workday.torque.pooling.ModuleInfo
 import com.workday.torque.pooling.TestChunk
-import com.workday.torque.pooling.TestModuleInfo
 import com.workday.torque.pooling.TestPool
-import io.mockk.Ordering
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
+import io.mockk.*
 import io.reactivex.Completable
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context


### PR DESCRIPTION
If the apk for a test chunk is not installed on the device yet, extend the timeout to cover install with retries.