### PR TITLE
Update boundary timeout to also count the original run before the ret…

### DIFF
--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -95,10 +95,10 @@ class TestRunFactory {
     }
 
     private fun getTimeoutMillis(args: Args, installer: Installer, testChunk: TestChunk): Long {
-        val possibleChunkRunCount = args.retriesPerChunk + 1
-        val possibleInstallCount = args.retriesInstallPerApk + 1
-        val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * possibleChunkRunCount
-        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * possibleChunkRunCount * possibleInstallCount
+        val allowedChunkRunCount = args.retriesPerChunk + 1
+        val allowedInstallCount = args.retriesInstallPerApk + 1
+        val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * allowedChunkRunCount
+        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * allowedChunkRunCount * allowedInstallCount
 
         return if (installer.isChunkApkInstalled(testChunk)) {
             chunkTimeOutWithRetries

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -95,13 +95,14 @@ class TestRunFactory {
     }
 
     private fun getTimeoutMillis(args: Args, installer: Installer, testChunk: TestChunk): Long {
-        val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * args.retriesPerChunk
-        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * args.retriesPerChunk * args.retriesInstallPerApk
+        val possibleChunkRunCount = args.retriesPerChunk + 1
+        val possibleInstallCount = args.retriesInstallPerApk + 1
+        val chunkTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.chunkTimeoutSeconds) * possibleChunkRunCount
+        val installTimeOutWithRetries = TimeUnit.SECONDS.toMillis(args.installTimeoutSeconds.toLong()) * possibleChunkRunCount * possibleInstallCount
 
         return if (installer.isChunkApkInstalled(testChunk)) {
             chunkTimeOutWithRetries
-        }
-        else {
+        } else {
             chunkTimeOutWithRetries + installTimeOutWithRetries
         }
     }


### PR DESCRIPTION
…ries, otherwise 1 "retry" would mean enough time for 1 run.