### PR TITLE
Add screen record for last fail. Also fix test file pulling logic.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.3-m3-SNAPSHOT
+VERSION_NAME=1.0.3
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.3-m2-SNAPSHOT
+VERSION_NAME=1.0.3-m3-SNAPSHOT
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.2
+VERSION_NAME=1.0.3-m2-SNAPSHOT
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/Args.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Args.kt
@@ -12,6 +12,7 @@ const val DEFAULT_CHUNK_SIZE = 1
 const val DEFAULT_PER_CHUNK_TIMEOUT_SECONDS = 120L
 const val DEFAULT_MAX_RETRIES_PER_CHUNK = 1
 const val DEFAULT_TORQUE_TIMEOUT_MINUTES = 60L
+const val DEFAULT_FILES_PULL_DEVICE_DIR_PATH = "/sdcard/test-files"
 
 data class Args(
         @Parameter(
@@ -112,24 +113,31 @@ data class Args(
 
         @Parameter(
                 names = ["--test-files-pull-device-directory"],
-                description = "Directory on device to pull test files from. Setting this directory and --file-pull-host-directory will enable recursive pulling of the folders." +
-                        "This folder would have the structure of deviceDirectory\\TestClass\\TestMethod for all tests"
+                description = "Directory on device to pull test files from. Setting this directory and --file-pull-host-directory will enable recursive pulling of the folders."
         )
-        var testFilesPullDeviceDirectory: String = "",
+        var testFilesPullDeviceDirectory: String = DEFAULT_FILES_PULL_DEVICE_DIR_PATH,
 
         @Parameter(
                 names = ["--test-files-pull-host-directory"],
-                description = "Directory on the Torque run host machine to pull test files to. Setting this and --file-pull-device-directory will enable pulling of the folders." +
-                        "This folder would have the structure of hostDirectory\\TestClass\\TestMethod for all tests"
+                description = "Directory on the Torque run host machine to pull test files into. Setting this and --file-pull-device-directory will enable pulling of the folders." +
+                        "This folder would have the structure of hostDirectory\\deviceDirectory"
         )
         var testFilesPullHostDirectory: String = "",
 
         @Parameter(
                 names = ["--uninstall-apk-after-test"],
+                arity = 1,
                 description = "Always only have one module's test apk and app apk installed per device. Uninstalls the current test modules and app modules when starting a different test module." +
                         "This is required when multiple apks contain the same intent filters due to AndroidManifest.xml merging."
         )
-        var uninstallApkAfterTest: Boolean = false
+        var uninstallApkAfterTest: Boolean = false,
+
+        @Parameter(
+                names = ["--record-failed-tests"],
+                arity = 1,
+                description = "Screen record failed tests on last try, file will be under"
+        )
+        var recordFailedTests: Boolean = false
 )
 
 fun parseArgs(rawArgs: Array<String>): Args {

--- a/torque-core/src/main/kotlin/com/workday/torque/FilePuller.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/FilePuller.kt
@@ -3,25 +3,22 @@ package com.workday.torque
 import com.gojuno.commander.os.Notification
 import io.reactivex.Completable
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 private const val MAX_RETRIES: Long = 3
 
 class FilePuller(private val adbDevice: AdbDevice,
                  private val processRunner: ProcessRunner = ProcessRunner()) {
 
-    fun pullTestFolder(
-            hostDirectory: String,
-            deviceDirectory: String,
-            testDetails: TestDetails,
-            timeout: Timeout
-    ): Completable {
-        val folderOnHostMachine = hostDirectory.setupFolderPathForTestDetails(testDetails)
+    fun pullFolder(args: Args, subFolder: String = ""): Completable {
+        val pullFileTimeout = Timeout(args.installTimeoutSeconds, TimeUnit.SECONDS)
+        val folderOnHostMachine = args.testFilesPullHostDirectory
         val folderOnHostMachineFile = File(folderOnHostMachine)
         folderOnHostMachineFile.mkdirs()
-        val folderOnDevice = deviceDirectory.setupFolderPathForTestDetails(testDetails)
+        val folderOnDevice = "${args.testFilesPullDeviceDirectory}/$subFolder"
         val pullFiles = processRunner.runAdb(
                 commandAndArgs = listOf("-s", adbDevice.id, "pull", folderOnDevice, folderOnHostMachineFile.absolutePath),
-                timeout = timeout,
+                timeout = pullFileTimeout,
                 unbufferedOutput = true
         )
 
@@ -33,9 +30,5 @@ class FilePuller(private val adbDevice: AdbDevice,
                 .doOnError { error -> adbDevice.log("Failed to pull files from $folderOnDevice to $folderOnHostMachine failed: $error") }
                 .ignoreElements()
                 .onErrorComplete()
-    }
-
-    private fun String.setupFolderPathForTestDetails(testDetails: TestDetails): String {
-        return "$this/${testDetails.testClass}/${testDetails.testName}"
     }
 }

--- a/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
@@ -1,0 +1,68 @@
+package com.workday.torque
+
+import com.gojuno.commander.os.Notification
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.await
+import java.io.File
+
+class ScreenRecorder(private val adbDevice: AdbDevice,
+                     args: Args,
+                     private val processRunner: ProcessRunner = ProcessRunner()) {
+    private val videosDir = File(File(args.testFilesPullDeviceDirectory, "videos"), adbDevice.id)
+    private val timeoutSeconds = args.chunkTimeoutSeconds
+    private var videoRecordJob: Job? = null
+    private lateinit var videoFileName: File
+
+    suspend fun start(coroutineScope: CoroutineScope, testDetails: TestDetails) {
+        videoRecordJob = coroutineScope.launch { startRecordTestRun(testDetails) }
+    }
+
+    private suspend fun startRecordTestRun(testDetails: TestDetails) {
+        videoFileName = getVideoFile(testDetails)
+
+        processRunner.runAdb(commandAndArgs = listOf(
+                "-s", adbDevice.id,
+                "shell", "mkdir -p ${videoFileName.parentFile}"
+        ),
+                destroyOnUnsubscribe = true)
+                .ofType(Notification.Exit::class.java)
+                .map { true }
+                .doOnError { error -> adbDevice.log("Failed to mkdir on ${adbDevice.tag}, filepath: ${videoFileName.parentFile}, failed: $error") }
+                .ignoreElements()
+                .await()
+
+        processRunner.runAdb(commandAndArgs = listOf(
+                "-s", adbDevice.id,
+                "shell", "screenrecord $videoFileName --time-limit $timeoutSeconds --size 720x1440"
+        ),
+                destroyOnUnsubscribe = true)
+                .ofType(Notification.Exit::class.java)
+                .map { true }
+                .doOnSubscribe { adbDevice.log("Started recording on ${adbDevice.tag}, filename: $videoFileName") }
+                .doOnComplete { adbDevice.log("Ended recording on ${adbDevice.tag}, filename: $videoFileName") }
+                .doOnError { error -> adbDevice.log("Failed to record on ${adbDevice.tag}, filename: $videoFileName, failed: $error") }
+                .ignoreElements()
+                .await()
+    }
+
+    private fun getVideoFile(testDetails: TestDetails): File {
+        val testFolder = File(File(videosDir, testDetails.testClass), testDetails.testName)
+        return File(testFolder, "failed_recording.mp4")
+    }
+
+    fun stop() = videoRecordJob?.cancel()
+
+    suspend fun removeLastFile() {
+        processRunner.runAdb(commandAndArgs = listOf(
+                "-s", adbDevice.id,
+                "shell", "rm $videoFileName"
+        ),
+                destroyOnUnsubscribe = true)
+                .ofType(Notification.Exit::class.java)
+                .map { true }
+                .ignoreElements()
+                .await()
+    }
+}

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -2,12 +2,10 @@ package com.workday.torque
 
 import com.workday.torque.pooling.TestPool
 import io.reactivex.Single
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asSingle
 import kotlinx.coroutines.rx2.await
 
@@ -66,11 +64,11 @@ class TestRunFactory {
         ).asSingle(Dispatchers.Default)
     }
 
-    private fun CoroutineScope.pullDeviceFiles(args: Args, filePuller: FilePuller) {
+    private suspend fun pullDeviceFiles(args: Args, filePuller: FilePuller) {
         if (args.testFilesPullDeviceDirectory.isEmpty() || args.testFilesPullHostDirectory.isEmpty()) {
             return
         }
 
-        launch { filePuller.pullFolder(args).await() }
+        filePuller.pullFolder(args).await()
     }
 }

--- a/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
@@ -194,4 +194,38 @@ class ArgsSpec : Spek(
             assertThat(args.testFilesPullHostDirectory).isEqualTo("hostDir")
         }
     }
+
+    context("parse args with explicitly passed --uninstall-apk-after-test") {
+
+        listOf(true, false).forEach { uninstallApkAfterTest ->
+
+            context("--uninstall-apk-after-test $uninstallApkAfterTest") {
+
+                val args by memoized {
+                    parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--uninstall-apk-after-test", "$uninstallApkAfterTest"))
+                }
+
+                it("parses --uninstall-apk-after-test correctly") {
+                    assertThat(args.uninstallApkAfterTest).isEqualTo(uninstallApkAfterTest)
+                }
+            }
+        }
+    }
+
+    context("parse args with explicitly passed --record-failed-tests") {
+
+        listOf(true, false).forEach { recordFailedTests ->
+
+            context("--record-failed-tests $recordFailedTests") {
+
+                val args by memoized {
+                    parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--record-failed-tests", "$recordFailedTests"))
+                }
+
+                it("parses --record-failed-tests correctly") {
+                    assertThat(args.recordFailedTests).isEqualTo(recordFailedTests)
+                }
+            }
+        }
+    }
 })

--- a/torque-core/src/test/kotlin/com/workday/torque/FilePullerSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/FilePullerSpec.kt
@@ -17,17 +17,18 @@ class FilePullerSpec : Spek(
     }
 
     given("A test detail") {
-        val hostDirectory = "someHostDir"
-        val deviceDirectory = "someDeviceDir"
-        val testDetails = TestDetails("com.some.package.class", "SomeTest")
+        val args = Args().apply {
+            testFilesPullDeviceDirectory = "someDeviceDir"
+            testFilesPullHostDirectory = "someHostDir"
+        }
         it("Runs adb pull command for that test folder") {
-            filePuller.pullTestFolder(hostDirectory, deviceDirectory, testDetails, mockk())
+            filePuller.pullFolder(args, "subFolder")
 
             verify {
                 val commandAndArgsMatcher = match<List<String>> {
                     it[0] == "-s" && it[1] == adbDevice.id && it[2] == "pull" &&
-                            it[3] == "someDeviceDir/com.some.package.class/SomeTest" &&
-                            it[4].endsWith("someHostDir/com.some.package.class/SomeTest")
+                            it[3] == "someDeviceDir/subFolder" &&
+                            it[4].endsWith("someHostDir")
                 }
                 processRunner.runAdb(commandAndArgsMatcher, any(), any(), any(), any(), any(), any())
             }

--- a/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
@@ -1,0 +1,59 @@
+package com.workday.torque
+
+import io.mockk.Ordering
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import io.reactivex.Observable
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class ScreenRecorderSpec : Spek(
+{
+    val adbDevice = AdbDevice("id", "model", true)
+    val processRunner by memoized {
+        mockk<ProcessRunner>(relaxed = true) {
+            coEvery { runAdb(allAny()) } returns Observable.empty()
+        }
+    }
+    val args = Args().apply {
+        testFilesPullDeviceDirectory = "someDeviceDir"
+        recordFailedTests = true
+    }
+    val videoRecorder by memoized {
+        ScreenRecorder(adbDevice, args, processRunner)
+    }
+
+    val testDetails = TestDetails("someTestClass", "someTestMethod")
+
+    given("ScreenRecorder session") {
+        it("start calls adb mkdir screen record and rm command for a test with correct path") {
+            runBlocking {
+                videoRecorder.start(this, testDetails)
+            }
+            runBlocking {
+                videoRecorder.removeLastFile()
+            }
+
+            verify(ordering = Ordering.ORDERED) {
+                val mkdirCommandAndArgsMatcher = match<List<String>> {
+                    it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
+                            it[3] == "mkdir -p someDeviceDir/videos/id/someTestClass/someTestMethod"
+                }
+                processRunner.runAdb(mkdirCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
+                val recordCommandAndArgsMatcher = match<List<String>> {
+                    it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
+                            it[3] == "screenrecord someDeviceDir/videos/id/someTestClass/someTestMethod/failed_recording.mp4 --time-limit $DEFAULT_PER_CHUNK_TIMEOUT_SECONDS --size 720x1440"
+                }
+                processRunner.runAdb(recordCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
+                val rmCommandAndArgsMatcher = match<List<String>> {
+                    it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
+                            it[3] == "rm someDeviceDir/videos/id/someTestClass/someTestMethod/failed_recording.mp4"
+                }
+                processRunner.runAdb(rmCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
+            }
+        }
+    }
+})

--- a/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
@@ -45,12 +45,12 @@ class ScreenRecorderSpec : Spek(
                 processRunner.runAdb(mkdirCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
                 val recordCommandAndArgsMatcher = match<List<String>> {
                     it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
-                            it[3] == "screenrecord someDeviceDir/videos/id/someTestClass/someTestMethod/failed_recording.mp4 --time-limit $DEFAULT_PER_CHUNK_TIMEOUT_SECONDS --size 720x1440"
+                            it[3] == "screenrecord someDeviceDir/videos/id/someTestClass/someTestMethod/test_recording.mp4 --time-limit $DEFAULT_PER_CHUNK_TIMEOUT_SECONDS --size 720x1440"
                 }
                 processRunner.runAdb(recordCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
                 val rmCommandAndArgsMatcher = match<List<String>> {
                     it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
-                            it[3] == "rm someDeviceDir/videos/id/someTestClass/someTestMethod/failed_recording.mp4"
+                            it[3] == "rm someDeviceDir/videos/id/someTestClass/someTestMethod/test_recording.mp4"
                 }
                 processRunner.runAdb(rmCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
             }


### PR DESCRIPTION
This optional function will record screen if it's on the last retry and it failed.
This helps with finding causes for intermittent diffs.

With correct args, out put path will look like this (open to suggestions):
```
.../build/Torque-Results/test-files/videos/localhost%3A5572/com.somecompany.someapp.CoolFeatureP1Test/coolFeatureViewLoadedTest/failed_recording.mp4
```