### PR TITLE
Fix logcatrecorder crashing Torque. As losing a test log is not that …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.3
+VERSION_NAME=1.0.4
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/LogcatRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/LogcatRecorder.kt
@@ -58,12 +58,14 @@ class LogcatRecorder(
     }
 
     private fun createAndInitTestLogcat(newLine: String): TestLogcat {
-        return TestLogcat(testDetails = newLine.parseTestDetails()!!)
+        val testDetails = newLine.parseTestDetails()
+                ?: TestDetails("CorruptFormatClass", "CorruptFormatMethod")
+        return TestLogcat(testDetails = testDetails)
                 .apply { appendNewLogLine(newLine) }
     }
 
     private fun TestLogcat.isMatchingFinishTestLogcat(newLine: String): Boolean {
-        return testDetails == newLine.parseTestDetails()!!
+        return testDetails == newLine.parseTestDetails()
     }
 
     private fun TestLogcat.finishAndWriteLogcatFile(newLine: String) {

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -20,7 +20,7 @@ class TestRunFactory {
                     timeoutSeconds = args.chunkTimeoutSeconds.toInt(),
                     outputDirPath = args.outputDirectory
             ),
-            logcatRecorder: LogcatRecorder = LogcatRecorder(logcatFileIO),
+            logcatRecorder: LogcatRecorder = LogcatRecorder(adbDevice, logcatFileIO),
             installer: Installer = Installer(adbDevice),
             filePuller: FilePuller = FilePuller(adbDevice),
             testChunkRunner: TestChunkRunner = TestChunkRunner(adbDevice, logcatFileIO, installer),

--- a/torque-core/src/test/kotlin/com/workday/torque/LogcatRecorderSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/LogcatRecorderSpec.kt
@@ -2,6 +2,7 @@ package com.workday.torque
 
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
@@ -42,14 +43,25 @@ class LogcatRecorderSpec : Spek(
                                  "11-09 16:13:22.746 21283 21301 I TestRunner: run finished: 2 tests, 0 failed, 0 ignored",
                                  "some logcat line"
     )
+    val fullLogcatLinesInvalidStart = listOf("some logcat line",
+            "TestRunner: started: someTestMethod1(someTestClass1)",
+            "some logcat line 1-1",
+            "some logcat line 1-2",
+            "TestRunner: started: someTestMethod2(someTestClass2)",
+            "some logcat line 2",
+            "TestRunner: finished: someTestMethod2(someTestClass2)"
+    )
+    val fullLogcatLinesInvalidFinish1 = listOf("some logcat line",
+            "TestRunner: finished: someTestMethod1(someTestClass1)",
+            "some logcat line"
+    )
+    val fullLogcatLinesInvalidFinish2 = listOf("some logcat line",
+            "TestRunner: started: someTestMethod1(someTestClass1)",
+            "some logcat line 1-1",
+            "some logcat line 1-2",
+            "TestRunner: finished: someTestMethod2(someTestClass2)"
+    )
     context("LogcatRecorder parses and saves logcat for each test") {
-        val logcatFileIo = mockk<LogcatFileIO> {
-            every { writeLogcatFileForTest(any()) } just Runs
-            coEvery { redirectLogcatToFile() } just Runs
-        }
-        val logcatRecorder by memoized {
-            LogcatRecorder(logcatFileIo)
-        }
         given("a Channel of newlines from the full logcat file with 2 chunks runs with 2 tests each") {
             val fullLogcatTailChannel by memoized {
                 Channel<String>(capacity = UNLIMITED)
@@ -60,7 +72,16 @@ class LogcatRecorderSpec : Spek(
                             close()
                         }
             }
-            coEvery { logcatFileIo.tailFile() } returns fullLogcatTailChannel
+            val logcatFileIo by memoized {
+                mockk<LogcatFileIO> {
+                    every { writeLogcatFileForTest(any()) } just Runs
+                    coEvery { redirectLogcatToFile() } just Runs
+                    every { tailFile() } returns fullLogcatTailChannel
+                }
+            }
+            val logcatRecorder by memoized {
+                LogcatRecorder(mockk(relaxed = true), logcatFileIo)
+            }
 
             it("redirects logcat, tails that file and emits 4 TestLogcat with correct fields") {
                 val testLogcat1 = TestLogcat(testDetails = TestDetails("someTestClass1", "someTestMethod1"),
@@ -95,6 +116,112 @@ class LogcatRecorderSpec : Spek(
                     logcatFileIo.writeLogcatFileForTest(testLogcat3)
                     logcatFileIo.writeLogcatFileForTest(testLogcat4)
                 }
+            }
+        }
+
+        given("a Channel of newlines from the full logcat file with invalid start") {
+            val fullLogcatTailChannel by memoized {
+                Channel<String>(capacity = UNLIMITED)
+                        .apply {
+                            fullLogcatLinesInvalidStart.forEach { line ->
+                                offer(line)
+                            }
+                            close()
+                        }
+            }
+            val logcatFileIo by memoized {
+                mockk<LogcatFileIO> {
+                    every { writeLogcatFileForTest(any()) } just Runs
+                    coEvery { redirectLogcatToFile() } just Runs
+                    every { tailFile() } returns fullLogcatTailChannel
+                }
+            }
+            val logcatRecorder by memoized {
+                LogcatRecorder(mockk(relaxed = true), logcatFileIo)
+            }
+
+            it("redirects logcat, tails that file and emits 2 TestLogcat with the first having an artificial end log and logs the next one normally") {
+                val testLogcat1 = TestLogcat(testDetails = TestDetails("someTestClass1", "someTestMethod1"),
+                        logcat = "TestRunner: started: someTestMethod1(someTestClass1)\n" +
+                                "some logcat line 1-1\n" +
+                                "some logcat line 1-2\n" +
+                                "[Torque]: Started next test without finishing the last one. Unfinished test: someTestClass1.someTestMethod1\n")
+
+                val testLogcat2 = TestLogcat(testDetails = TestDetails("someTestClass2", "someTestMethod2"),
+                        logcat = "TestRunner: started: someTestMethod2(someTestClass2)\n" +
+                                "some logcat line 2\n" +
+                                "TestRunner: finished: someTestMethod2(someTestClass2)\n")
+
+                runBlocking {
+                    logcatRecorder.start(this)
+                }
+
+                coVerifyOrder {
+                    logcatFileIo.redirectLogcatToFile()
+                    logcatFileIo.tailFile()
+                    logcatFileIo.writeLogcatFileForTest(testLogcat1)
+                    logcatFileIo.writeLogcatFileForTest(testLogcat2)
+                }
+            }
+        }
+
+        given("a Channel of newlines from the full logcat file with invalid finish that had no start") {
+            val fullLogcatTailChannel by memoized {
+                Channel<String>(capacity = UNLIMITED)
+                        .apply {
+                            fullLogcatLinesInvalidFinish1.forEach { line ->
+                                offer(line)
+                            }
+                            close()
+                        }
+            }
+            val logcatFileIo by memoized {
+                mockk<LogcatFileIO> {
+                    every { writeLogcatFileForTest(any()) } just Runs
+                    coEvery { redirectLogcatToFile() } just Runs
+                    every { tailFile() } returns fullLogcatTailChannel
+                }
+            }
+            val logcatRecorder by memoized {
+                LogcatRecorder(mockk(relaxed = true), logcatFileIo)
+            }
+
+            it("does not call writeLogcatFileForTest") {
+                runBlocking {
+                    logcatRecorder.start(this)
+                }
+
+                coVerify(exactly = 0) { logcatFileIo.writeLogcatFileForTest(any()) }
+            }
+        }
+
+        given("a Channel of newlines from the full logcat file with invalid finish that had wrong start") {
+            val fullLogcatTailChannel by memoized {
+                Channel<String>(capacity = UNLIMITED)
+                        .apply {
+                            fullLogcatLinesInvalidFinish2.forEach { line ->
+                                offer(line)
+                            }
+                            close()
+                        }
+            }
+            val logcatFileIo by memoized {
+                mockk<LogcatFileIO> {
+                    every { writeLogcatFileForTest(any()) } just Runs
+                    coEvery { redirectLogcatToFile() } just Runs
+                    every { tailFile() } returns fullLogcatTailChannel
+                }
+            }
+            val logcatRecorder by memoized {
+                LogcatRecorder(mockk(relaxed = true), logcatFileIo)
+            }
+
+            it("does not call writeLogcatFileForTest") {
+                runBlocking {
+                    logcatRecorder.start(this)
+                }
+
+                coVerify(exactly = 0) { logcatFileIo.writeLogcatFileForTest(any()) }
             }
         }
     }


### PR DESCRIPTION
…problematic and mismatched start/finish logs are pretty common.