### PR TITLE
Failing build when torque fails

### DIFF
--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
@@ -88,12 +88,7 @@ class TorquePlugin : Plugin<Project> {
     private fun configureTaskOptionsAndRun(torqueArgs: Args, task: TorqueRunTask) {
         torqueArgs.configureTaskOptions(task)
         println("Starting Torque run with args: $torqueArgs")
-        try {
-            Torque(torqueArgs).run()
-        } catch (e: Exception) {
-            println("Torque run failed with exception: ${e.message}")
-            e.printStackTrace()
-        }
+        Torque(torqueArgs).run()
     }
 
     private fun Args.configureTaskOptions(task: TorqueRunTask) {


### PR DESCRIPTION
It should be easier to find the error if we also fail the build when an error occurs.