### PR TITLE
Set the process timeout to equal the chunk timeout plus a buffer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.6
+VERSION_NAME=1.0.7
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import java.io.File
+import java.util.concurrent.TimeUnit
+
+private const val TIMEOUT_BUFFER_SECONDS = 10
 
 class ScreenRecorder(private val adbDevice: AdbDevice,
                      args: Args,
@@ -37,7 +40,8 @@ class ScreenRecorder(private val adbDevice: AdbDevice,
                 "-s", adbDevice.id,
                 "shell", "screenrecord $videoFileName --time-limit $timeoutSeconds --size 720x1440"
         ),
-                destroyOnUnsubscribe = true)
+                destroyOnUnsubscribe = true,
+                timeout = Timeout(timeoutSeconds.toInt() + TIMEOUT_BUFFER_SECONDS, TimeUnit.SECONDS))
                 .ofType(Notification.Exit::class.java)
                 .map { true }
                 .doOnSubscribe { adbDevice.log("Started recording on ${adbDevice.tag}, filename: $videoFileName") }


### PR DESCRIPTION
The ScreenRecorder process timeout was using the default arg of 120 seconds but it's possible to set the chunk timeout to be greater than that. This was causing the screen recordings to not be saved when the process times out before the chunk. I set the process time out to equal the chunk plus a 10 second buffer to avoid race conditions