### PR TITLE
Fix run command string

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.6
+VERSION_NAME=1.0.7
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import java.io.File
+import java.util.concurrent.TimeUnit
+
+private const val TIMEOUT_BUFFER_SECONDS = 10
 
 class ScreenRecorder(private val adbDevice: AdbDevice,
                      args: Args,
@@ -37,7 +40,8 @@ class ScreenRecorder(private val adbDevice: AdbDevice,
                 "-s", adbDevice.id,
                 "shell", "screenrecord $videoFileName --time-limit $timeoutSeconds --size 720x1440"
         ),
-                destroyOnUnsubscribe = true)
+                destroyOnUnsubscribe = true,
+                timeout = Timeout(timeoutSeconds.toInt() + TIMEOUT_BUFFER_SECONDS, TimeUnit.SECONDS))
                 .ofType(Notification.Exit::class.java)
                 .map { true }
                 .doOnSubscribe { adbDevice.log("Started recording on ${adbDevice.tag}, filename: $videoFileName") }

--- a/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.rx2.await
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-const val TIMEOUT_BUFFER_SECONDS = 10
+internal const val TIMEOUT_BUFFER_SECONDS = 10
 
 class ScreenRecorder(private val adbDevice: AdbDevice,
                      args: Args,

--- a/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ScreenRecorder.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.rx2.await
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-private const val TIMEOUT_BUFFER_SECONDS = 10
+const val TIMEOUT_BUFFER_SECONDS = 10
 
 class ScreenRecorder(private val adbDevice: AdbDevice,
                      args: Args,

--- a/torque-core/src/main/kotlin/com/workday/torque/TestChunkRunner.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestChunkRunner.kt
@@ -45,9 +45,9 @@ class TestChunkRunner(
         val testMethodsArgs = "-e class " + testChunk.testMethods.joinToString(",") { it.testName }
         val timeout = Timeout(chunkTimeoutSeconds.toInt(), TimeUnit.SECONDS)
         val runCommand = if(args.testCoverageEnabled && shouldPullTestFiles(args)) {
-            "am instrument -w -r -e coverage true -e \"coverageFile ${args.testFilesPullDeviceDirectory}/coverage-reports/$coverageFileName\" \"$testMethodsArgs $testPackageName/$testRunnerClass\""
+            "am instrument -w -r -e coverage true -e coverageFile ${args.testFilesPullDeviceDirectory}/coverage-reports/$coverageFileName $testMethodsArgs $testPackageName/$testRunnerClass"
         } else {
-            "am instrument -w -r \"$testMethodsArgs $testPackageName/$testRunnerClass\""
+            "am instrument -w -r $testMethodsArgs $testPackageName/$testRunnerClass"
         }
         return processRunner.runAdb(commandAndArgs = listOf("-s", adbDevice.id, "shell", runCommand), timeout = timeout)
                 .ofType(Notification.Start::class.java)

--- a/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ScreenRecorderSpec.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import java.util.concurrent.TimeUnit
 
 class ScreenRecorderSpec : Spek(
 {
@@ -47,7 +48,18 @@ class ScreenRecorderSpec : Spek(
                     it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
                             it[3] == "screenrecord someDeviceDir/videos/id/someTestClass/someTestMethod/test_recording.mp4 --time-limit $DEFAULT_PER_CHUNK_TIMEOUT_SECONDS --size 720x1440"
                 }
-                processRunner.runAdb(recordCommandAndArgsMatcher, any(), any(), any(), any(), any(), any())
+                val expectedTimeout = Timeout(
+                        DEFAULT_PER_CHUNK_TIMEOUT_SECONDS.toInt() + TIMEOUT_BUFFER_SECONDS,
+                        TimeUnit.SECONDS)
+
+                processRunner.runAdb(commandAndArgs = recordCommandAndArgsMatcher,
+                        timeout = expectedTimeout,
+                        redirectOutputTo = any(),
+                        keepOutputOnExit = any(),
+                        unbufferedOutput = any(),
+                        print = any(),
+                        destroyOnUnsubscribe = any())
+
                 val rmCommandAndArgsMatcher = match<List<String>> {
                     it[0] == "-s" && it[1] == adbDevice.id && it[2] == "shell" &&
                             it[3] == "rm someDeviceDir/videos/id/someTestClass/someTestMethod/test_recording.mp4"


### PR DESCRIPTION
The run command strings have extra quotes which are causing an InstrumentationReader timeout exception. I removed the quotes and it's working