### PR TITLE
fixed an issue with min api 24 apps using torque

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,7 +10,7 @@ ext.versions = [
         apacheCommonsIo    : '2.5',
         apacheCommonsLang  : '3.5',
         gson               : '2.8.0',
-        dexParser          : '1.1.0',
+        dexParser          : '2.3.1',
         junit              : '4.12',
         junitPlatform      : '1.2.0',
         spek               : '1.2.1',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.8
+VERSION_NAME=1.0.9
 GROUP=com.workday
 
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.

--- a/torque-core/src/main/kotlin/com/workday/torque/ApkTestParser.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ApkTestParser.kt
@@ -122,6 +122,6 @@ class ApkTestParser {
     fun getTests(testApkPath: String) = parseTests(testApkPath)
 
     private fun parseTests(testApkPath: String): List<TestMethod> =
-            DexParser.findTestMethods(testApkPath).map { TestMethod(it.testName, it.annotationNames) }
+            DexParser.findTestMethods(testApkPath).map { TestMethod(it.testName, it.annotations) }
 
 }

--- a/torque-core/src/main/kotlin/com/workday/torque/Args.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Args.kt
@@ -25,20 +25,20 @@ data class Args(
         var testApkPaths: List<String> = emptyList(),
 
         @Parameter(
-                names = ["--allowed-annotations"],
+                names = ["--included-annotations"],
                 variableArity = true,
                 description = "Run only test methods WITH specified annotations. If multiple annotations are specified, will only run tests that are annotated with all of them. " +
                         "None by default and runs all tests. If used with other options, will run the intersection of them."
         )
-        var allowedAnnotations: List<String> = emptyList(),
+        var includedAnnotations: List<String> = emptyList(),
 
         @Parameter(
-                names = ["--prohibited-annotations"],
+                names = ["--excluded-annotations"],
                 variableArity = true,
                 description = "Run only test methods WITHOUT specified annotations. If multiple annotations are specified, will only run tests that are not annotated with any of them. " +
                         "Contains @Ignore by default. If used with other options, will run the intersection of them."
         )
-        var prohibitedAnnotations: List<String> = DEFAULT_NOT_ANNOTATIONS,
+        var excludedAnnotations: List<String> = DEFAULT_NOT_ANNOTATIONS,
 
         @Parameter(
                 names = ["--class-regex"],

--- a/torque-core/src/main/kotlin/com/workday/torque/Args.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Args.kt
@@ -3,7 +3,7 @@ package com.workday.torque
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
 
-val DEFAULT_NOT_ANNOTATIONS = listOf("Ignore")
+val DEFAULT_NOT_ANNOTATIONS = listOf("org.junit.Ignore")
 const val DEFAULT_INSTALL_TIMEOUT_SECONDS = 30
 const val DEFAULT_MAX_INSTALL_RETRIES_PER_APK = 2L
 const val DEFAULT_OUTPUT_DIR_PATH = "torque-output"
@@ -25,20 +25,20 @@ data class Args(
         var testApkPaths: List<String> = emptyList(),
 
         @Parameter(
-                names = ["--annotations"],
+                names = ["--allowed-annotations"],
                 variableArity = true,
                 description = "Run only test methods WITH specified annotations. If multiple annotations are specified, will only run tests that are annotated with all of them. " +
                         "None by default and runs all tests. If used with other options, will run the intersection of them."
         )
-        var annotations: List<String> = emptyList(),
+        var allowedAnnotations: List<String> = emptyList(),
 
         @Parameter(
-                names = ["--not-annotations"],
+                names = ["--prohibited-annotations"],
                 variableArity = true,
                 description = "Run only test methods WITHOUT specified annotations. If multiple annotations are specified, will only run tests that are not annotated with any of them. " +
                         "Contains @Ignore by default. If used with other options, will run the intersection of them."
         )
-        var notAnnotations: List<String> = DEFAULT_NOT_ANNOTATIONS,
+        var prohibitedAnnotations: List<String> = DEFAULT_NOT_ANNOTATIONS,
 
         @Parameter(
                 names = ["--class-regex"],

--- a/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
@@ -10,7 +10,7 @@ class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTes
         return args.testApkPaths.fold(mutableListOf()) { accumulatedModules, testApkPath ->
             accumulatedModules.apply {
                 val testMethods = apkTestParser.getTests(testApkPath)
-                        .filterAnnotations(allowedAnnotations = args.allowedAnnotations, prohibitedAnnotations = args.prohibitedAnnotations)
+                        .filterAnnotations(includedAnnotations = args.includedAnnotations, excludedAnnotations = args.excludedAnnotations)
                         .filterClassRegexes(args.testClassRegexes)
                 println("Filtered tests count: ${testMethods.size}")
                 val moduleInfo = createModuleInfo(testApkPath)
@@ -20,18 +20,18 @@ class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTes
     }
 
     private fun List<TestMethod>.filterAnnotations(
-            allowedAnnotations: List<String>,
-            prohibitedAnnotations: List<String>
+			includedAnnotations: List<String>,
+			excludedAnnotations: List<String>
     ): List<TestMethod> {
-        return filter { it.isValidAfterAnnotationsCheck(allowedAnnotations = allowedAnnotations, prohibitedAnnotations = prohibitedAnnotations) }
+        return filter { it.isValidAfterAnnotationsCheck(includedAnnotations = includedAnnotations, excludedAnnotations = excludedAnnotations) }
     }
 
     private fun TestMethod.isValidAfterAnnotationsCheck(
-            allowedAnnotations: List<String>,
-            prohibitedAnnotations: List<String>
+			includedAnnotations: List<String>,
+			excludedAnnotations: List<String>
     ): Boolean {
-        return annotations.all { allowedAnnotations.hasAnnotation(it.name) }
-                && prohibitedAnnotations.all { allowedAnnotations.hasAnnotation(it).not() }
+        return annotations.all { includedAnnotations.hasAnnotation(it.name) }
+                && excludedAnnotations.all { includedAnnotations.hasAnnotation(it).not() }
     }
 
     private fun List<String>.hasAnnotation(annotation: String): Boolean {

--- a/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
@@ -10,7 +10,7 @@ class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTes
         return args.testApkPaths.fold(mutableListOf()) { accumulatedModules, testApkPath ->
             accumulatedModules.apply {
                 val testMethods = apkTestParser.getTests(testApkPath)
-                        .filterAnnotations(annotations = args.annotations, notAnnotations = args.notAnnotations)
+                        .filterAnnotations(allowedAnnotations = args.allowedAnnotations, prohibitedAnnotations = args.prohibitedAnnotations)
                         .filterClassRegexes(args.testClassRegexes)
                 println("Filtered tests count: ${testMethods.size}")
                 val moduleInfo = createModuleInfo(testApkPath)
@@ -20,18 +20,18 @@ class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTes
     }
 
     private fun List<TestMethod>.filterAnnotations(
-            annotations: List<String>,
-            notAnnotations: List<String>
+            allowedAnnotations: List<String>,
+            prohibitedAnnotations: List<String>
     ): List<TestMethod> {
-        return filter { it.isValidAfterAnnotationsCheck(annotations = annotations, notAnnotations = notAnnotations) }
+        return filter { it.isValidAfterAnnotationsCheck(allowedAnnotations = allowedAnnotations, prohibitedAnnotations = prohibitedAnnotations) }
     }
 
     private fun TestMethod.isValidAfterAnnotationsCheck(
-            annotations: List<String>,
-            notAnnotations: List<String>
+            allowedAnnotations: List<String>,
+            prohibitedAnnotations: List<String>
     ): Boolean {
-        return annotations.all { annotationNames.hasAnnotation(it) }
-                && notAnnotations.all { annotationNames.hasAnnotation(it).not() }
+        return annotations.all { allowedAnnotations.hasAnnotation(it.name) }
+                && prohibitedAnnotations.all { allowedAnnotations.hasAnnotation(it).not() }
     }
 
     private fun List<String>.hasAnnotation(annotation: String): Boolean {

--- a/torque-core/src/test/kotlin/com/workday/torque/ApkTestParserSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ApkTestParserSpec.kt
@@ -1,6 +1,10 @@
 package com.workday.torque
 
 import com.linkedin.dex.parser.TestMethod
+import com.workday.torque.utils.RUNS_WITH_ANDROID_ANNOTATION
+import com.workday.torque.utils.TEST_ANNOTATION
+import com.workday.torque.utils.THROWS_EXCEPTION_ANNOTATION
+import com.workday.torque.utils.assertAnnotationArrays
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
@@ -25,11 +29,17 @@ class ApkTestParserSpec : Spek({
         }
 
         it("parses tests list correctly") {
-            assertThat(apkTestParser.getTests(testApkPath)).isEqualTo(listOf(
+            val expectedTestMethods = listOf(
                     TestMethod("test.test.myapplication.ExampleInstrumentedTest#useAppContext",
-                               listOf("dalvik.annotation.Throws", "org.junit.Test", "org.junit.runner.RunWith")
-                    )
-            ))
+                            listOf(RUNS_WITH_ANDROID_ANNOTATION,
+                                    THROWS_EXCEPTION_ANNOTATION,
+                                    TEST_ANNOTATION)
+                    ))
+            val actualTestMethods = apkTestParser.getTests(testApkPath)
+            expectedTestMethods.zip(actualTestMethods).forEach { (expected, actual) ->
+                assertThat(expected.testName).isEqualTo(actual.testName)
+                assertAnnotationArrays(expected.annotations, actual.annotations)
+            }
         }
     }
 })

--- a/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
@@ -19,8 +19,8 @@ class ArgsSpec : Spek(
         it("parses passes testApkPaths and uses default values for other fields") {
             assertThat(args).isEqualTo(Args(
                     testApkPaths = listOf("test-apk-path-1", "test-apk-path-2"),
-                    annotations = emptyList(),
-                    notAnnotations = DEFAULT_NOT_ANNOTATIONS,
+                    allowedAnnotations = emptyList(),
+                    prohibitedAnnotations = DEFAULT_NOT_ANNOTATIONS,
                     testClassRegexes = emptyList(),
                     appApkPath = "",
                     chunkSize = DEFAULT_CHUNK_SIZE,
@@ -38,22 +38,22 @@ class ArgsSpec : Spek(
     context("parse args with explicitly passed --annotations") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--annotations", "Annotation1", "Annotation2"))
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--allowed-annotations", "Annotation1", "Annotation2"))
         }
 
-        it("parses --annotations correctly") {
-            assertThat(args.annotations).isEqualTo(listOf("Annotation1", "Annotation2"))
+        it("parses --allowed-annotations correctly") {
+            assertThat(args.allowedAnnotations).isEqualTo(listOf("Annotation1", "Annotation2"))
         }
     }
 
-    context("parse args with explicitly passed --not-annotations") {
+    context("parse args with explicitly passed --prohibited-annotations") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--not-annotations", "NotAnnotation1", "NotAnnotation2"))
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--prohibited-annotations", "NotAnnotation1", "NotAnnotation2"))
         }
 
-        it("parses --not-annotations correctly") {
-            assertThat(args.notAnnotations).isEqualTo(listOf("NotAnnotation1", "NotAnnotation2"))
+        it("parses --prohibited-annotations correctly") {
+            assertThat(args.prohibitedAnnotations).isEqualTo(listOf("NotAnnotation1", "NotAnnotation2"))
         }
     }
 

--- a/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ArgsSpec.kt
@@ -19,8 +19,8 @@ class ArgsSpec : Spek(
         it("parses passes testApkPaths and uses default values for other fields") {
             assertThat(args).isEqualTo(Args(
                     testApkPaths = listOf("test-apk-path-1", "test-apk-path-2"),
-                    allowedAnnotations = emptyList(),
-                    prohibitedAnnotations = DEFAULT_NOT_ANNOTATIONS,
+                    includedAnnotations = emptyList(),
+                    excludedAnnotations = DEFAULT_NOT_ANNOTATIONS,
                     testClassRegexes = emptyList(),
                     appApkPath = "",
                     chunkSize = DEFAULT_CHUNK_SIZE,
@@ -35,25 +35,25 @@ class ArgsSpec : Spek(
         }
     }
 
-    context("parse args with explicitly passed --annotations") {
+    context("parse args with explicitly passed --included-annotations") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--allowed-annotations", "Annotation1", "Annotation2"))
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--included-annotations", "Annotation1", "Annotation2"))
         }
 
-        it("parses --allowed-annotations correctly") {
-            assertThat(args.allowedAnnotations).isEqualTo(listOf("Annotation1", "Annotation2"))
+        it("parses --included-annotations correctly") {
+            assertThat(args.includedAnnotations).isEqualTo(listOf("Annotation1", "Annotation2"))
         }
     }
 
-    context("parse args with explicitly passed --prohibited-annotations") {
+    context("parse args with explicitly passed --excluded-annotations") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--prohibited-annotations", "NotAnnotation1", "NotAnnotation2"))
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--excluded-annotations", "NotAnnotation1", "NotAnnotation2"))
         }
 
-        it("parses --prohibited-annotations correctly") {
-            assertThat(args.prohibitedAnnotations).isEqualTo(listOf("NotAnnotation1", "NotAnnotation2"))
+        it("parses --excluded-annotations correctly") {
+            assertThat(args.excludedAnnotations).isEqualTo(listOf("NotAnnotation1", "NotAnnotation2"))
         }
     }
 

--- a/torque-core/src/test/kotlin/com/workday/torque/ModuleTestParserSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ModuleTestParserSpec.kt
@@ -4,6 +4,7 @@ import com.linkedin.dex.parser.TestMethod
 import com.workday.torque.pooling.ModuleInfo
 import com.workday.torque.pooling.TestModule
 import com.workday.torque.pooling.TestModuleInfo
+import com.workday.torque.utils.*
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -13,232 +14,248 @@ import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
 class ModuleTestParserSpec : Spek(
-{
-    context("parse multiple tests modules from apks") {
-        val moduleCount = 10
-        val testApkPath = fileFromJarResources<InstrumentationSpec>("instrumentation-test.apk").absolutePath
-        val args = Args().apply {
-            testApkPaths = MutableList(moduleCount) { testApkPath }
-        }
+        {
+            context("parse multiple tests modules from apks") {
+                val moduleCount = 10
+                val testApkPath = fileFromJarResources<InstrumentationSpec>("instrumentation-test.apk").absolutePath
+                val args = Args().apply {
+                    testApkPaths = MutableList(moduleCount) { testApkPath }
+                }
 
-        it("parses TestModules correctly") {
-            val expectedTestModules = createExpectedTestModules(testApkPath, moduleCount)
-
-            assertThat(ModuleTestParser(args).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-        }
-    }
-
-    context("parse tests with different test annotations") {
-        val noAnnotationsTest = TestMethod("com.company.mymodule.test#testNoAnnotations",
-                                           listOf("org.junit.Test", "kotlin.Metadata"))
-        val ignoredTest = TestMethod("com.company.mymodule.test#testIgnored",
-                                     listOf("org.junit.Ignore", "org.junit.Test", "kotlin.Metadata"))
-        val mediumTest = TestMethod("com.company.mymodule.test#testMediumTest",
-                                    listOf("android.support.test.filters.MediumTest", "org.junit.Test",
-                                           "kotlin.Metadata"))
-        val flakyMediumTest = TestMethod("com.company.mymodule.test#testMultiAnnotations",
-                                              listOf("android.support.test.filters.MediumTest",
-                                                     "android.support.test.filters.FlakyTest", "org.junit.Test",
-                                                     "kotlin.Metadata"))
-        val ignoredFlakyMediumTest = TestMethod("com.company.mymodule.test#testPositiveNegativeAnnotations",
-                                                         listOf("org.junit.Ignore",
-                                                            "android.support.test.filters.MediumTest",
-                                                            "android.support.test.filters.FlakyTest", "org.junit.Test",
-                                                            "kotlin.Metadata"))
-        val testMethods = listOf(
-                noAnnotationsTest,
-                ignoredTest,
-                mediumTest,
-                flakyMediumTest,
-                ignoredFlakyMediumTest)
-        val testPackage = ApkPackage.Valid("com.company.mymodule.test")
-        val targetPackage = ApkPackage.Valid("test.test.myapplication")
-        val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-        val apkTestParser = mockk<ApkTestParser> {
-            every { getValidatedTestPackage(any()) } returns testPackage
-            every { getValidatedTargetPackage(any()) } returns targetPackage
-            every { getValidatedTestRunner(any()) } returns testRunner
-            every { getTests(any()) } returns testMethods
-        }
-        val targetApkPath = "some_app_path"
-        val testApkPath = "some_path"
-        val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
-
-        given("no Annotations and with default Ignore NotAnnotations") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
+                it("parses TestModules correctly") {
+                    val expectedTestModules = createExpectedTestModules(testApkPath, moduleCount)
+                    val actualTestModules = ModuleTestParser(args).parseTestsFromModuleApks()
+                    expectedTestModules.zip(actualTestModules).forEach { (expected, actual) ->
+                        assertThat(expected.testModuleInfo).isEqualTo(actual.testModuleInfo)
+                        expected.testMethods.zip(actual.testMethods).forEach { (expected, actual) ->
+                            assertThat(expected.testName).isEqualTo(actual.testName)
+                            assertAnnotationArrays(expected.annotations, actual.annotations)
+                        }
+                    }
+                }
             }
 
-            it("filters out Ignored tests only") {
-                val expectedTestMethods = listOf(
+            context("parse tests with different test annotations") {
+                val noAnnotationsTest = TestMethod("com.company.mymodule.test#testNoAnnotations",
+                        listOf(TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val ignoredTest = TestMethod("com.company.mymodule.test#testIgnored",
+                        listOf(IGNORE_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val mediumTest = TestMethod("com.company.mymodule.test#testMediumTest",
+                        listOf(MEDIUM_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val flakyMediumTest = TestMethod("com.company.mymodule.test#testMultiAnnotations",
+                        listOf(MEDIUM_TEST_ANNOTATION,
+                                FLAKY_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val ignoredFlakyMediumTest = TestMethod("com.company.mymodule.test#testPositiveNegativeAnnotations",
+                        listOf(IGNORE_TEST_ANNOTATION,
+                                MEDIUM_TEST_ANNOTATION,
+                                FLAKY_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val testMethods = listOf(
                         noAnnotationsTest,
+                        ignoredTest,
                         mediumTest,
+                        flakyMediumTest,
+                        ignoredFlakyMediumTest)
+                val testPackage = ApkPackage.Valid("com.company.mymodule.test")
+                val targetPackage = ApkPackage.Valid("test.test.myapplication")
+                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+                val apkTestParser = mockk<ApkTestParser> {
+                    every { getValidatedTestPackage(any()) } returns testPackage
+                    every { getValidatedTargetPackage(any()) } returns targetPackage
+                    every { getValidatedTestRunner(any()) } returns testRunner
+                    every { getTests(any()) } returns testMethods
+                }
+                val targetApkPath = "some_app_path"
+                val testApkPath = "some_path"
+                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
+
+                given("no Annotations and with default Ignore NotAnnotations") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                    }
+
+                    it("filters out Ignored tests only") {
+                        val expectedTestMethods = listOf(
+                                noAnnotationsTest,
+                                mediumTest,
+                                flakyMediumTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+                        assertTestModules(expectedTestModules, actualTestModules)
+                    }
+                }
+
+                given("MediumTest Annotations and with default Ignore NotAnnotations") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        allowedAnnotations = listOf("MediumTest")
+                    }
+
+                    it("filters to MediumTests only") {
+                        val expectedTestMethods = listOf(mediumTest, flakyMediumTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+                        assertTestModules(expectedTestModules, actualTestModules)
+                    }
+                }
+
+                given("MediumTest FlakyTest Annotations and with default Ignore NotAnnotations") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        allowedAnnotations = listOf("android.support.test.filters.MediumTest", "android.support.test.filters.FlakyTest")
+                    }
+
+                    it("filters to MediumTest FlakyTest tests only") {
+                        val expectedTestMethods = listOf(flakyMediumTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+                        assertTestModules(expectedTestModules, actualTestModules)
+                    }
+                }
+
+                given("FlakyTest ProhibitedAnnotations") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        prohibitedAnnotations = listOf("android.support.test.filters.FlakyTest")
+                    }
+
+                    it("filters out FlakyTest tests only") {
+                        val expectedTestMethods = listOf(noAnnotationsTest, ignoredTest, mediumTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+                        assertTestModules(expectedTestModules, actualTestModules)
+                    }
+                }
+            }
+
+            context("parse tests with test class regex") {
+                val prefixSomeSpecificTest = TestMethod("com.company.mymodule1.PrefixSomeSpecificTest#someTestMethod", emptyList())
+                val prefixSpecificTest = TestMethod("com.company.mymodule2.PrefixSpecificTest#someTestMethod", emptyList())
+                val someOtherTest = TestMethod("com.company.myapp.SomeOtherTest#someTestMethod", emptyList())
+                val testMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
+                val testPackage = ApkPackage.Valid("com.company.myapp.test")
+                val targetPackage = ApkPackage.Valid("test.test.myapplication")
+                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+                val apkTestParser = mockk<ApkTestParser> {
+                    every { getValidatedTestPackage(any()) } returns testPackage
+                    every { getValidatedTargetPackage(any()) } returns targetPackage
+                    every { getValidatedTestRunner(any()) } returns testRunner
+                    every { getTests(any()) } returns testMethods
+                }
+                val targetApkPath = "some_app_path"
+                val testApkPath = "some_test_path"
+                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
+
+                given("no regex provided ") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                    }
+
+                    it("filters to all tests") {
+                        val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+
+                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+                    }
+                }
+
+                given("single regex string") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        testClassRegexes = listOf("(Prefix[a-zA-Z]*SpecificTest)+")
+                    }
+
+                    it("filters to regex matching tests only") {
+                        val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+
+                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+                    }
+                }
+
+                given("multiple regex strings") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        testClassRegexes = listOf("(PrefixSpecificTest)+", "(SomeOtherTest)+")
+                    }
+
+                    it("filters to regex matching tests only") {
+                        val expectedTestMethods = listOf(prefixSpecificTest, someOtherTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+
+                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+                    }
+                }
+            }
+
+            context("parse tests with annotations and regex") {
+                val noAnnotationsSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+                        listOf(TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val mediumSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+                        listOf(MEDIUM_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val mediumOtherTest = TestMethod("com.company.mymodule.SomeOtherTest#someTest",
+                        listOf(MEDIUM_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val flakyMediumTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+                        listOf(MEDIUM_TEST_ANNOTATION,
+                                FLAKY_TEST_ANNOTATION,
+                                TEST_ANNOTATION,
+                                METADATA_ANNOTATION))
+                val testMethods = listOf(
+                        noAnnotationsSpecificTest,
+                        mediumSpecificTest,
+                        mediumOtherTest,
                         flakyMediumTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                val testPackage = ApkPackage.Valid("com.company.mymodule.test")
+                val targetPackage = ApkPackage.Valid("test.test.myapplication")
+                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+                val apkTestParser = mockk<ApkTestParser> {
+                    every { getValidatedTestPackage(any()) } returns testPackage
+                    every { getValidatedTargetPackage(any()) } returns targetPackage
+                    every { getValidatedTestRunner(any()) } returns testRunner
+                    every { getTests(any()) } returns testMethods
+                }
+                val targetApkPath = "some_app_path"
+                val testApkPath = "some_test_path"
+                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
 
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+                given("MediumTest Annotations, FlakyTest ProhibitedAnnotations and regex") {
+                    val args = Args().apply {
+                        testApkPaths = listOf(testApkPath)
+                        appApkPath = targetApkPath
+                        allowedAnnotations = listOf("android.support.test.filters.MediumTest")
+                        prohibitedAnnotations = listOf("android.support.test.filters.FlakyTest")
+                        testClassRegexes = listOf("[a-zA-Z]+SpecificTest")
+                    }
+
+                    it("filters to MediumTests Non-FlakyTest SpecificTest only") {
+                        val expectedTestMethods = listOf(mediumSpecificTest)
+                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+                        assertTestModules(expectedTestModules, actualTestModules)
+                    }
+                }
             }
-        }
-
-        given("MediumTest Annotations and with default Ignore NotAnnotations") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                annotations = listOf("MediumTest")
-            }
-
-            it("filters to MediumTests only") {
-                val expectedTestMethods = listOf(mediumTest, flakyMediumTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-
-        given("MediumTest FlakyTest Annotations and with default Ignore NotAnnotations") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                annotations = listOf("MediumTest", "FlakyTest")
-            }
-
-            it("filters to MediumTest FlakyTest tests only") {
-                val expectedTestMethods = listOf(flakyMediumTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-
-        given("FlakyTest NotAnnotations") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                notAnnotations = listOf("FlakyTest")
-            }
-
-            it("filters out FlakyTest tests only") {
-                val expectedTestMethods = listOf(noAnnotationsTest, ignoredTest, mediumTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-    }
-
-    context("parse tests with test class regex") {
-        val prefixSomeSpecificTest = TestMethod("com.company.mymodule1.PrefixSomeSpecificTest#someTestMethod", emptyList())
-        val prefixSpecificTest = TestMethod("com.company.mymodule2.PrefixSpecificTest#someTestMethod", emptyList())
-        val someOtherTest = TestMethod("com.company.myapp.SomeOtherTest#someTestMethod", emptyList())
-        val testMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
-        val testPackage = ApkPackage.Valid("com.company.myapp.test")
-        val targetPackage = ApkPackage.Valid("test.test.myapplication")
-        val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-        val apkTestParser = mockk<ApkTestParser> {
-            every { getValidatedTestPackage(any()) } returns testPackage
-            every { getValidatedTargetPackage(any()) } returns targetPackage
-            every { getValidatedTestRunner(any()) } returns testRunner
-            every { getTests(any()) } returns testMethods
-        }
-        val targetApkPath = "some_app_path"
-        val testApkPath = "some_test_path"
-        val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
-
-        given("no regex provided ") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-            }
-
-            it("filters to all tests") {
-                val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-
-        given("single regex string") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                testClassRegexes = listOf("(Prefix[a-zA-Z]*SpecificTest)+")
-            }
-
-            it("filters to regex matching tests only") {
-                val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-
-        given("multiple regex strings") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                testClassRegexes = listOf("(PrefixSpecificTest)+", "(SomeOtherTest)+")
-            }
-
-            it("filters to regex matching tests only") {
-                val expectedTestMethods = listOf(prefixSpecificTest, someOtherTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-    }
-
-    context("parse tests with annotations and regex") {
-        val noAnnotationsSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                listOf("org.junit.Test", "kotlin.Metadata"))
-        val mediumSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                listOf("android.support.test.filters.MediumTest", "org.junit.Test",
-                        "kotlin.Metadata"))
-        val mediumOtherTest = TestMethod("com.company.mymodule.SomeOtherTest#someTest",
-                listOf("android.support.test.filters.MediumTest", "org.junit.Test",
-                        "kotlin.Metadata"))
-        val flakyMediumTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                listOf("android.support.test.filters.MediumTest",
-                        "android.support.test.filters.FlakyTest", "org.junit.Test",
-                        "kotlin.Metadata"))
-        val testMethods = listOf(
-                noAnnotationsSpecificTest,
-                mediumSpecificTest,
-                mediumOtherTest,
-                flakyMediumTest)
-        val testPackage = ApkPackage.Valid("com.company.mymodule.test")
-        val targetPackage = ApkPackage.Valid("test.test.myapplication")
-        val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-        val apkTestParser = mockk<ApkTestParser> {
-            every { getValidatedTestPackage(any()) } returns testPackage
-            every { getValidatedTargetPackage(any()) } returns targetPackage
-            every { getValidatedTestRunner(any()) } returns testRunner
-            every { getTests(any()) } returns testMethods
-        }
-        val targetApkPath = "some_app_path"
-        val testApkPath = "some_test_path"
-        val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
-
-        given("MediumTest Annotations, FlakyTest NotAnnotations and regex") {
-            val args = Args().apply {
-                testApkPaths = listOf(testApkPath)
-                appApkPath = targetApkPath
-                annotations = listOf("MediumTest")
-                notAnnotations = listOf("FlakyTest")
-                testClassRegexes = listOf("[a-zA-Z]+SpecificTest")
-            }
-
-            it("filters to MediumTests Non-FlakyTest SpecificTest only") {
-                val expectedTestMethods = listOf(mediumSpecificTest)
-                val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-
-                assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-            }
-        }
-    }
-})
+        })
 
 private fun createExpectedTestModules(testApkPath: String, moduleCount: Int): List<TestModule> {
     val testPackage = ApkPackage.Valid("test.test.myapplication.test")
@@ -246,8 +263,10 @@ private fun createExpectedTestModules(testApkPath: String, moduleCount: Int): Li
     val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
     val testMethods = listOf(
             TestMethod("test.test.myapplication.ExampleInstrumentedTest#useAppContext",
-                       listOf("dalvik.annotation.Throws", "org.junit.Test", "org.junit.runner.RunWith")
-                      ))
+                    listOf(RUNS_WITH_ANDROID_ANNOTATION,
+                            THROWS_EXCEPTION_ANNOTATION,
+                            TEST_ANNOTATION)
+            ))
     val moduleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, ""))
     return MutableList(moduleCount) { TestModule(moduleInfo, testMethods) }
 }

--- a/torque-core/src/test/kotlin/com/workday/torque/ModuleTestParserSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/ModuleTestParserSpec.kt
@@ -14,259 +14,259 @@ import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
 class ModuleTestParserSpec : Spek(
-        {
-            context("parse multiple tests modules from apks") {
-                val moduleCount = 10
-                val testApkPath = fileFromJarResources<InstrumentationSpec>("instrumentation-test.apk").absolutePath
-                val args = Args().apply {
-                    testApkPaths = MutableList(moduleCount) { testApkPath }
-                }
+{
+	context("parse multiple tests modules from apks") {
+		val moduleCount = 10
+		val testApkPath = fileFromJarResources<InstrumentationSpec>("instrumentation-test.apk").absolutePath
+		val args = Args().apply {
+			testApkPaths = MutableList(moduleCount) { testApkPath }
+		}
 
-                it("parses TestModules correctly") {
-                    val expectedTestModules = createExpectedTestModules(testApkPath, moduleCount)
-                    val actualTestModules = ModuleTestParser(args).parseTestsFromModuleApks()
-                    expectedTestModules.zip(actualTestModules).forEach { (expected, actual) ->
-                        assertThat(expected.testModuleInfo).isEqualTo(actual.testModuleInfo)
-                        expected.testMethods.zip(actual.testMethods).forEach { (expected, actual) ->
-                            assertThat(expected.testName).isEqualTo(actual.testName)
-                            assertAnnotationArrays(expected.annotations, actual.annotations)
-                        }
-                    }
-                }
-            }
+		it("parses TestModules correctly") {
+			val expectedTestModules = createExpectedTestModules(testApkPath, moduleCount)
+			val actualTestModules = ModuleTestParser(args).parseTestsFromModuleApks()
+			expectedTestModules.zip(actualTestModules).forEach { (expected, actual) ->
+				assertThat(expected.testModuleInfo).isEqualTo(actual.testModuleInfo)
+				expected.testMethods.zip(actual.testMethods).forEach { (expected, actual) ->
+					assertThat(expected.testName).isEqualTo(actual.testName)
+					assertAnnotationArrays(expected.annotations, actual.annotations)
+				}
+			}
+		}
+	}
 
-            context("parse tests with different test annotations") {
-                val noAnnotationsTest = TestMethod("com.company.mymodule.test#testNoAnnotations",
-                        listOf(TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val ignoredTest = TestMethod("com.company.mymodule.test#testIgnored",
-                        listOf(IGNORE_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val mediumTest = TestMethod("com.company.mymodule.test#testMediumTest",
-                        listOf(MEDIUM_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val flakyMediumTest = TestMethod("com.company.mymodule.test#testMultiAnnotations",
-                        listOf(MEDIUM_TEST_ANNOTATION,
-                                FLAKY_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val ignoredFlakyMediumTest = TestMethod("com.company.mymodule.test#testPositiveNegativeAnnotations",
-                        listOf(IGNORE_TEST_ANNOTATION,
-                                MEDIUM_TEST_ANNOTATION,
-                                FLAKY_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val testMethods = listOf(
-                        noAnnotationsTest,
-                        ignoredTest,
-                        mediumTest,
-                        flakyMediumTest,
-                        ignoredFlakyMediumTest)
-                val testPackage = ApkPackage.Valid("com.company.mymodule.test")
-                val targetPackage = ApkPackage.Valid("test.test.myapplication")
-                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-                val apkTestParser = mockk<ApkTestParser> {
-                    every { getValidatedTestPackage(any()) } returns testPackage
-                    every { getValidatedTargetPackage(any()) } returns targetPackage
-                    every { getValidatedTestRunner(any()) } returns testRunner
-                    every { getTests(any()) } returns testMethods
-                }
-                val targetApkPath = "some_app_path"
-                val testApkPath = "some_path"
-                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
+	context("parse tests with different test annotations") {
+		val noAnnotationsTest = TestMethod("com.company.mymodule.test#testNoAnnotations",
+				listOf(TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val ignoredTest = TestMethod("com.company.mymodule.test#testIgnored",
+				listOf(IGNORE_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val mediumTest = TestMethod("com.company.mymodule.test#testMediumTest",
+				listOf(MEDIUM_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val flakyMediumTest = TestMethod("com.company.mymodule.test#testMultiAnnotations",
+				listOf(MEDIUM_TEST_ANNOTATION,
+						FLAKY_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val ignoredFlakyMediumTest = TestMethod("com.company.mymodule.test#testPositiveNegativeAnnotations",
+				listOf(IGNORE_TEST_ANNOTATION,
+						MEDIUM_TEST_ANNOTATION,
+						FLAKY_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val testMethods = listOf(
+				noAnnotationsTest,
+				ignoredTest,
+				mediumTest,
+				flakyMediumTest,
+				ignoredFlakyMediumTest)
+		val testPackage = ApkPackage.Valid("com.company.mymodule.test")
+		val targetPackage = ApkPackage.Valid("test.test.myapplication")
+		val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+		val apkTestParser = mockk<ApkTestParser> {
+			every { getValidatedTestPackage(any()) } returns testPackage
+			every { getValidatedTargetPackage(any()) } returns targetPackage
+			every { getValidatedTestRunner(any()) } returns testRunner
+			every { getTests(any()) } returns testMethods
+		}
+		val targetApkPath = "some_app_path"
+		val testApkPath = "some_path"
+		val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
 
-                given("no Annotations and with default Ignore NotAnnotations") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                    }
+		given("no Annotations and with default Ignore NotAnnotations") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+			}
 
-                    it("filters out Ignored tests only") {
-                        val expectedTestMethods = listOf(
-                                noAnnotationsTest,
-                                mediumTest,
-                                flakyMediumTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
-                        assertTestModules(expectedTestModules, actualTestModules)
-                    }
-                }
+			it("filters out Ignored tests only") {
+				val expectedTestMethods = listOf(
+						noAnnotationsTest,
+						mediumTest,
+						flakyMediumTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+				val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+				assertTestModules(expectedTestModules, actualTestModules)
+			}
+		}
 
-                given("MediumTest Annotations and with default Ignore NotAnnotations") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        allowedAnnotations = listOf("MediumTest")
-                    }
+		given("MediumTest Annotations and with default Ignore NotAnnotations") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				includedAnnotations = listOf("MediumTest")
+			}
 
-                    it("filters to MediumTests only") {
-                        val expectedTestMethods = listOf(mediumTest, flakyMediumTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
-                        assertTestModules(expectedTestModules, actualTestModules)
-                    }
-                }
+			it("filters to MediumTests only") {
+				val expectedTestMethods = listOf(mediumTest, flakyMediumTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+				val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+				assertTestModules(expectedTestModules, actualTestModules)
+			}
+		}
 
-                given("MediumTest FlakyTest Annotations and with default Ignore NotAnnotations") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        allowedAnnotations = listOf("android.support.test.filters.MediumTest", "android.support.test.filters.FlakyTest")
-                    }
+		given("MediumTest FlakyTest Annotations and with default Ignore NotAnnotations") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				includedAnnotations = listOf("android.support.test.filters.MediumTest", "android.support.test.filters.FlakyTest")
+			}
 
-                    it("filters to MediumTest FlakyTest tests only") {
-                        val expectedTestMethods = listOf(flakyMediumTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
-                        assertTestModules(expectedTestModules, actualTestModules)
-                    }
-                }
+			it("filters to MediumTest FlakyTest tests only") {
+				val expectedTestMethods = listOf(flakyMediumTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+				val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+				assertTestModules(expectedTestModules, actualTestModules)
+			}
+		}
 
-                given("FlakyTest ProhibitedAnnotations") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        prohibitedAnnotations = listOf("android.support.test.filters.FlakyTest")
-                    }
+		given("FlakyTest ExcludedAnnotations") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				excludedAnnotations = listOf("android.support.test.filters.FlakyTest")
+			}
 
-                    it("filters out FlakyTest tests only") {
-                        val expectedTestMethods = listOf(noAnnotationsTest, ignoredTest, mediumTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
-                        assertTestModules(expectedTestModules, actualTestModules)
-                    }
-                }
-            }
+			it("filters out FlakyTest tests only") {
+				val expectedTestMethods = listOf(noAnnotationsTest, ignoredTest, mediumTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+				val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+				assertTestModules(expectedTestModules, actualTestModules)
+			}
+		}
+	}
 
-            context("parse tests with test class regex") {
-                val prefixSomeSpecificTest = TestMethod("com.company.mymodule1.PrefixSomeSpecificTest#someTestMethod", emptyList())
-                val prefixSpecificTest = TestMethod("com.company.mymodule2.PrefixSpecificTest#someTestMethod", emptyList())
-                val someOtherTest = TestMethod("com.company.myapp.SomeOtherTest#someTestMethod", emptyList())
-                val testMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
-                val testPackage = ApkPackage.Valid("com.company.myapp.test")
-                val targetPackage = ApkPackage.Valid("test.test.myapplication")
-                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-                val apkTestParser = mockk<ApkTestParser> {
-                    every { getValidatedTestPackage(any()) } returns testPackage
-                    every { getValidatedTargetPackage(any()) } returns targetPackage
-                    every { getValidatedTestRunner(any()) } returns testRunner
-                    every { getTests(any()) } returns testMethods
-                }
-                val targetApkPath = "some_app_path"
-                val testApkPath = "some_test_path"
-                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
+	context("parse tests with test class regex") {
+		val prefixSomeSpecificTest = TestMethod("com.company.mymodule1.PrefixSomeSpecificTest#someTestMethod", emptyList())
+		val prefixSpecificTest = TestMethod("com.company.mymodule2.PrefixSpecificTest#someTestMethod", emptyList())
+		val someOtherTest = TestMethod("com.company.myapp.SomeOtherTest#someTestMethod", emptyList())
+		val testMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
+		val testPackage = ApkPackage.Valid("com.company.myapp.test")
+		val targetPackage = ApkPackage.Valid("test.test.myapplication")
+		val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+		val apkTestParser = mockk<ApkTestParser> {
+			every { getValidatedTestPackage(any()) } returns testPackage
+			every { getValidatedTargetPackage(any()) } returns targetPackage
+			every { getValidatedTestRunner(any()) } returns testRunner
+			every { getTests(any()) } returns testMethods
+		}
+		val targetApkPath = "some_app_path"
+		val testApkPath = "some_test_path"
+		val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
 
-                given("no regex provided ") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                    }
+		given("no regex provided ") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+			}
 
-                    it("filters to all tests") {
-                        val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+			it("filters to all tests") {
+				val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest, someOtherTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
 
-                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-                    }
-                }
+				assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+			}
+		}
 
-                given("single regex string") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        testClassRegexes = listOf("(Prefix[a-zA-Z]*SpecificTest)+")
-                    }
+		given("single regex string") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				testClassRegexes = listOf("(Prefix[a-zA-Z]*SpecificTest)+")
+			}
 
-                    it("filters to regex matching tests only") {
-                        val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+			it("filters to regex matching tests only") {
+				val expectedTestMethods = listOf(prefixSomeSpecificTest, prefixSpecificTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
 
-                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-                    }
-                }
+				assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+			}
+		}
 
-                given("multiple regex strings") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        testClassRegexes = listOf("(PrefixSpecificTest)+", "(SomeOtherTest)+")
-                    }
+		given("multiple regex strings") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				testClassRegexes = listOf("(PrefixSpecificTest)+", "(SomeOtherTest)+")
+			}
 
-                    it("filters to regex matching tests only") {
-                        val expectedTestMethods = listOf(prefixSpecificTest, someOtherTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+			it("filters to regex matching tests only") {
+				val expectedTestMethods = listOf(prefixSpecificTest, someOtherTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
 
-                        assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
-                    }
-                }
-            }
+				assertThat(ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()).isEqualTo(expectedTestModules)
+			}
+		}
+	}
 
-            context("parse tests with annotations and regex") {
-                val noAnnotationsSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                        listOf(TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val mediumSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                        listOf(MEDIUM_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val mediumOtherTest = TestMethod("com.company.mymodule.SomeOtherTest#someTest",
-                        listOf(MEDIUM_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val flakyMediumTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
-                        listOf(MEDIUM_TEST_ANNOTATION,
-                                FLAKY_TEST_ANNOTATION,
-                                TEST_ANNOTATION,
-                                METADATA_ANNOTATION))
-                val testMethods = listOf(
-                        noAnnotationsSpecificTest,
-                        mediumSpecificTest,
-                        mediumOtherTest,
-                        flakyMediumTest)
-                val testPackage = ApkPackage.Valid("com.company.mymodule.test")
-                val targetPackage = ApkPackage.Valid("test.test.myapplication")
-                val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-                val apkTestParser = mockk<ApkTestParser> {
-                    every { getValidatedTestPackage(any()) } returns testPackage
-                    every { getValidatedTargetPackage(any()) } returns targetPackage
-                    every { getValidatedTestRunner(any()) } returns testRunner
-                    every { getTests(any()) } returns testMethods
-                }
-                val targetApkPath = "some_app_path"
-                val testApkPath = "some_test_path"
-                val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
+	context("parse tests with annotations and regex") {
+		val noAnnotationsSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+				listOf(TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val mediumSpecificTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+				listOf(MEDIUM_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val mediumOtherTest = TestMethod("com.company.mymodule.SomeOtherTest#someTest",
+				listOf(MEDIUM_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val flakyMediumTest = TestMethod("com.company.mymodule.SomeSpecificTest#someTest",
+				listOf(MEDIUM_TEST_ANNOTATION,
+						FLAKY_TEST_ANNOTATION,
+						TEST_ANNOTATION,
+						METADATA_ANNOTATION))
+		val testMethods = listOf(
+				noAnnotationsSpecificTest,
+				mediumSpecificTest,
+				mediumOtherTest,
+				flakyMediumTest)
+		val testPackage = ApkPackage.Valid("com.company.mymodule.test")
+		val targetPackage = ApkPackage.Valid("test.test.myapplication")
+		val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+		val apkTestParser = mockk<ApkTestParser> {
+			every { getValidatedTestPackage(any()) } returns testPackage
+			every { getValidatedTargetPackage(any()) } returns targetPackage
+			every { getValidatedTestRunner(any()) } returns testRunner
+			every { getTests(any()) } returns testMethods
+		}
+		val targetApkPath = "some_app_path"
+		val testApkPath = "some_test_path"
+		val testModuleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, targetApkPath))
 
-                given("MediumTest Annotations, FlakyTest ProhibitedAnnotations and regex") {
-                    val args = Args().apply {
-                        testApkPaths = listOf(testApkPath)
-                        appApkPath = targetApkPath
-                        allowedAnnotations = listOf("android.support.test.filters.MediumTest")
-                        prohibitedAnnotations = listOf("android.support.test.filters.FlakyTest")
-                        testClassRegexes = listOf("[a-zA-Z]+SpecificTest")
-                    }
+		given("MediumTest Annotations, FlakyTest ExcludedAnnotations and regex") {
+			val args = Args().apply {
+				testApkPaths = listOf(testApkPath)
+				appApkPath = targetApkPath
+				includedAnnotations = listOf("android.support.test.filters.MediumTest")
+				excludedAnnotations = listOf("android.support.test.filters.FlakyTest")
+				testClassRegexes = listOf("[a-zA-Z]+SpecificTest")
+			}
 
-                    it("filters to MediumTests Non-FlakyTest SpecificTest only") {
-                        val expectedTestMethods = listOf(mediumSpecificTest)
-                        val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
-                        val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
-                        assertTestModules(expectedTestModules, actualTestModules)
-                    }
-                }
-            }
-        })
+			it("filters to MediumTests Non-FlakyTest SpecificTest only") {
+				val expectedTestMethods = listOf(mediumSpecificTest)
+				val expectedTestModules = listOf(TestModule(testModuleInfo, expectedTestMethods))
+				val actualTestModules = ModuleTestParser(args, apkTestParser).parseTestsFromModuleApks()
+				assertTestModules(expectedTestModules, actualTestModules)
+			}
+		}
+	}
+})
 
 private fun createExpectedTestModules(testApkPath: String, moduleCount: Int): List<TestModule> {
-    val testPackage = ApkPackage.Valid("test.test.myapplication.test")
-    val targetPackage = ApkPackage.Valid("test.test.myapplication")
-    val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
-    val testMethods = listOf(
-            TestMethod("test.test.myapplication.ExampleInstrumentedTest#useAppContext",
-                    listOf(RUNS_WITH_ANDROID_ANNOTATION,
-                            THROWS_EXCEPTION_ANNOTATION,
-                            TEST_ANNOTATION)
-            ))
-    val moduleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, ""))
-    return MutableList(moduleCount) { TestModule(moduleInfo, testMethods) }
+	val testPackage = ApkPackage.Valid("test.test.myapplication.test")
+	val targetPackage = ApkPackage.Valid("test.test.myapplication")
+	val testRunner = TestRunner.Valid("android.support.test.runner.AndroidJUnitRunner")
+	val testMethods = listOf(
+			TestMethod("test.test.myapplication.ExampleInstrumentedTest#useAppContext",
+					listOf(RUNS_WITH_ANDROID_ANNOTATION,
+							THROWS_EXCEPTION_ANNOTATION,
+							TEST_ANNOTATION)
+			))
+	val moduleInfo = TestModuleInfo(ModuleInfo(testPackage, testApkPath), testRunner, ModuleInfo(targetPackage, ""))
+	return MutableList(moduleCount) { TestModule(moduleInfo, testMethods) }
 }

--- a/torque-core/src/test/kotlin/com/workday/torque/utils/TestUtils.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/utils/TestUtils.kt
@@ -1,7 +1,55 @@
 package com.workday.torque.utils
 
+import com.linkedin.dex.parser.DecodedValue
+import com.linkedin.dex.parser.TestAnnotation
 import com.linkedin.dex.parser.TestMethod
+import com.workday.torque.pooling.TestModule
+import org.assertj.core.api.Assertions
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+val THROWS_EXCEPTION_ANNOTATION = TestAnnotation("dalvik.annotation.Throws", values = mapOf("value" to DecodedValue.DecodedArrayValue(values= arrayOf(DecodedValue.DecodedType(value="Ljava/lang/Exception;")))), inherited = false)
+val TEST_ANNOTATION = TestAnnotation(name = "org.junit.Test", values = mapOf(), inherited = false)
+val RUNS_WITH_ANDROID_ANNOTATION = TestAnnotation("org.junit.runner.RunWith", values = mapOf("value" to DecodedValue.DecodedType(value="Landroid/support/test/runner/AndroidJUnit4;")), inherited = true)
+val MEDIUM_TEST_ANNOTATION = TestAnnotation("android.support.test.filters.MediumTest", values = mapOf(), inherited = false)
+val METADATA_ANNOTATION = TestAnnotation("kotlin.Metadata", values = mapOf(), inherited = false)
+val FLAKY_TEST_ANNOTATION = TestAnnotation("android.support.test.filters.FlakyTest", values = mapOf(), inherited = false)
+val IGNORE_TEST_ANNOTATION = TestAnnotation("org.junit.Ignore", values = mapOf(), inherited = false)
 
 fun createTestMethodsList(size: Int): MutableList<TestMethod> {
-    return MutableList(size) { TestMethod("test#somemethod", listOf("org.junit.Test")) }
+    return MutableList(size) { TestMethod("test#somemethod", listOf(TestAnnotation("org.junit.Test", values = mapOf(), inherited = false))) }
+}
+
+fun assertTestModules(expectedModules: List<TestModule>, actualTestModule: List<TestModule>) {
+    expectedModules.zip(actualTestModule).forEach { (expected, actual) ->
+        Assertions.assertThat(expected.testModuleInfo).isEqualTo(actual.testModuleInfo)
+        expected.testMethods.zip(actual.testMethods).forEach { (expected, actual) ->
+            assertEquals(expected.testName, actual.testName)
+            assertAnnotationArrays(expected.annotations, actual.annotations)
+        }
+    }
+}
+
+fun assertAnnotationArrays(expectedAnnotations: List<TestAnnotation>, actualAnnotations: List<TestAnnotation>) {
+    expectedAnnotations.zip(actualAnnotations).forEach { (expected, actual) ->
+        expected.assertAnnotations(actual)
+    }
+}
+
+private fun TestAnnotation.assertAnnotations(other: TestAnnotation) {
+    assertEquals(name, other.name)
+    assertEquals(inherited, other.inherited)
+    values.forEach { (key, value) ->
+        assertTrue(other.values.containsKey(key))
+        val otherValue = other.values.getValue(key)
+        value.assertDecodeValue(otherValue)
+    }
+}
+
+private fun DecodedValue.assertDecodeValue(other: DecodedValue) {
+    if(this is DecodedValue.DecodedArrayValue && other is DecodedValue.DecodedArrayValue) {
+        assertTrue(values.contentDeepEquals(other.values))
+    } else {
+        assertEquals(this, other)
+    }
 }

--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
@@ -92,12 +92,12 @@ class TorquePlugin : Plugin<Project> {
     }
 
     private fun Args.configureTaskOptions(task: TorqueRunTask) {
-        if (task.annotations.isNotEmpty()) {
-            annotations = task.annotations
+        if (task.allowedAnnotations.isNotEmpty()) {
+            allowedAnnotations = task.allowedAnnotations
         }
 
-        if (task.notAnnotations.isNotEmpty()) {
-            notAnnotations = task.notAnnotations
+        if (task.prohibitedAnnotations.isNotEmpty()) {
+            prohibitedAnnotations = task.prohibitedAnnotations
         }
 
         if (task.testClassRegexes.isNotEmpty()) {

--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
@@ -92,12 +92,12 @@ class TorquePlugin : Plugin<Project> {
     }
 
     private fun Args.configureTaskOptions(task: TorqueRunTask) {
-        if (task.allowedAnnotations.isNotEmpty()) {
-            allowedAnnotations = task.allowedAnnotations
+        if (task.includedAnnotations.isNotEmpty()) {
+            includedAnnotations = task.includedAnnotations
         }
 
-        if (task.prohibitedAnnotations.isNotEmpty()) {
-            prohibitedAnnotations = task.prohibitedAnnotations
+        if (task.excludedAnnotations.isNotEmpty()) {
+            excludedAnnotations = task.excludedAnnotations
         }
 
         if (task.testClassRegexes.isNotEmpty()) {

--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorqueRunTask.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorqueRunTask.kt
@@ -5,9 +5,9 @@ import org.gradle.api.tasks.options.Option
 
 open class TorqueRunTask: DefaultTask() {
 
-    var allowedAnnotations: List<String> = emptyList()
+    var includedAnnotations: List<String> = emptyList()
         @Option(option = "annotations", description = "annotations for tests to be ran") set
-    var prohibitedAnnotations: List<String> = emptyList()
+    var excludedAnnotations: List<String> = emptyList()
         @Option(option = "notAnnotations", description = "annotations for tests not to be ran") set
     var testClassRegexes: List<String> = emptyList()
         @Option(option = "testClassRegexes", description = "regex for tests to be ran") set

--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorqueRunTask.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorqueRunTask.kt
@@ -5,9 +5,9 @@ import org.gradle.api.tasks.options.Option
 
 open class TorqueRunTask: DefaultTask() {
 
-    var annotations: List<String> = emptyList()
+    var allowedAnnotations: List<String> = emptyList()
         @Option(option = "annotations", description = "annotations for tests to be ran") set
-    var notAnnotations: List<String> = emptyList()
+    var prohibitedAnnotations: List<String> = emptyList()
         @Option(option = "notAnnotations", description = "annotations for tests not to be ran") set
     var testClassRegexes: List<String> = emptyList()
         @Option(option = "testClassRegexes", description = "regex for tests to be ran") set


### PR DESCRIPTION
Found an issue with parsing dex files when migrating to min api 24. Updated the dex parsing library which caused some api changes. Also updated some arg names to be a bit more descriptive of what they are actually doing.