### PR TITLE
Update torque to use aapt2

### DIFF
--- a/torque-core/build.gradle
+++ b/torque-core/build.gradle
@@ -41,3 +41,15 @@ junitPlatform {
         }
     }
 }
+
+jar {
+    manifest {
+        attributes 'Implementation-Title': POM_NAME,
+          'Built-Date': new Date(),
+          'Built-JDK': System.getProperty('java.version'),
+          'Built-Gradle': gradle.gradleVersion
+    }
+    from {
+        configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
+    }
+}

--- a/torque-gradle-plugin/build.gradle
+++ b/torque-gradle-plugin/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 }
 
 jar {
+    entryCompression = ZipEntryCompression.STORED
     manifest {
         attributes 'Implementation-Title': POM_NAME,
                 'Built-Date': new Date(),

--- a/torque-runner/build.gradle
+++ b/torque-runner/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
 
 jar {
+    entryCompression = ZipEntryCompression.STORED
     // Build jar with dependencies.
     from(configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }) {
         exclude 'META-INF/*.SF'


### PR DESCRIPTION
At present, Torque uses the `aapt` tool to work with APKs. However, that tool has been long deprecated, and is now causing some problems.

This PR updates Torque to use the recommended `aapt2` tool, instead.