### PR TITLE
Handle agp7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.2
+VERSION_NAME=1.1.4
 GROUP=com.workday
 POM_DESCRIPTION=A Reactive Android instrumentation test orchestrator with multi-library-modules-testing and test pooling/grouping support.
 POM_URL=https://github.com/Workday/torque

--- a/torque-core/src/main/kotlin/com/workday/torque/AdbCommander.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/AdbCommander.kt
@@ -1,0 +1,57 @@
+package com.workday.torque
+
+import com.gojuno.commander.android.AdbDevice
+import com.gojuno.commander.android.adb
+import com.gojuno.commander.android.deviceModel
+import com.gojuno.commander.os.Notification
+import com.gojuno.commander.os.log
+import com.gojuno.commander.os.process
+import rx.Observable
+
+fun connectedAdbDevices(unbufferedOutput: Boolean = true): Observable<Set<AdbDevice>> {
+    return process(
+        commandAndArgs = listOf(adb, "devices"),
+        unbufferedOutput = unbufferedOutput
+    )
+        .ofType(Notification.Exit::class.java)
+        .map { it.output.readText() }
+        .map {
+            when (it.contains("List of devices attached")) {
+                true -> it
+                false -> throw IllegalStateException("Adb output is not correct: $it.")
+            }
+        }
+        .retry { retryCount, exception ->
+            val shouldRetry = retryCount < 5 && exception is IllegalStateException
+            if (shouldRetry) {
+                log("runningEmulators: retrying $exception.")
+            }
+
+            shouldRetry
+        }
+        .flatMapIterable {
+            it
+                .substringAfter("List of devices attached")
+                .split(System.lineSeparator())
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .filter { it.contains("online") || it.contains("device") }
+        }
+        .map { line ->
+            val serial = line.substringBefore("\t")
+            val online = when {
+                line.contains("offline", ignoreCase = true) -> false
+                line.contains("device", ignoreCase = true) -> true
+                else -> throw IllegalStateException("Unknown adb output for device: $line")
+            }
+            AdbDevice(id = serial, online = online)
+        }
+        .flatMapSingle { device ->
+            deviceModel(device).map { model ->
+                device.copy(model = model)
+            }
+        }
+        .toList()
+        .map { it.toSet() }
+        .doOnError { log("Error during getting connectedAdbDevices, error = $it") }
+}

--- a/torque-core/src/main/kotlin/com/workday/torque/AdbDeviceFinder.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/AdbDeviceFinder.kt
@@ -1,13 +1,12 @@
 package com.workday.torque
 
-import com.gojuno.commander.android.connectedAdbDevices
 import com.gojuno.commander.os.log
 import io.reactivex.Single
 
 class AdbDeviceFinder {
 
     fun onlineAdbDevices(): Single<List<AdbDevice>> {
-        return connectedAdbDevices()
+        return connectedAdbDevices(unbufferedOutput = false)
                 .toSingle()
                 .toV2Single()
                 .map {

--- a/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ModuleTestParser.kt
@@ -9,14 +9,16 @@ import com.workday.torque.pooling.TestModuleInfo
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTestParser = ApkTestParser()) {
+class ModuleTestParser(private val args: Args, private val apkTestParser: ApkTestParser = ApkTestParser(args.verboseOutput)) {
     fun parseTestsFromModuleApks(): List<TestModule> {
         return args.testApkPaths.fold(mutableListOf()) { accumulatedModules, testApkPath ->
             accumulatedModules.apply {
                 val testMethods = apkTestParser.getTests(testApkPath)
                         .filterAnnotations(includedAnnotations = args.includedAnnotations, excludedAnnotations = args.excludedAnnotations)
                         .filterClassRegexes(args.testClassRegexes)
-                println("Filtered tests count: ${testMethods.size}")
+                if (args.verboseOutput) {
+                    log("Filtered tests count: ${testMethods.size}")
+                }
                 val testApkFile = File(testApkPath)
 
                 val time = System.currentTimeMillis()

--- a/torque-core/src/main/kotlin/com/workday/torque/ResultWriter.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/ResultWriter.kt
@@ -6,18 +6,21 @@ import com.workday.torque.html.writeHtmlReport
 import java.io.File
 import java.util.Date
 
-class ResultWriter(val args: Args) {
+class ResultWriter(args: Args, workingDirectory: String) {
+
+    private val outputDirectory = "$workingDirectory/${args.outputDirectory}"
+    private val resultFilePath = "$workingDirectory/${args.resultFilePath}"
 
     fun clearOutputDirectory() {
-        File(args.outputDirectory).deleteRecursively()
+        File(outputDirectory).deleteRecursively()
     }
 
     fun write(startTime: Long,  adbDeviceTestSessions: List<AdbDeviceTestSession>) {
-        adbDeviceTestSessions.writeCiResultToOutputFile(args.resultFilePath)
+        adbDeviceTestSessions.writeCiResultToOutputFile(resultFilePath)
         val suites = adbDeviceTestSessions.toSuites()
         suites.run {
-            generateHtmlReport(args.outputDirectory)
-            generateJunit4Report(args.outputDirectory)
+            generateHtmlReport(outputDirectory)
+            generateJunit4Report(outputDirectory)
             printFinalResult(startTime)
         }
     }

--- a/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/TestRunFactory.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.rx2.asSingle
 import kotlinx.coroutines.rx2.await
 
-class TestRunFactory {
+class TestRunFactory(private val workingDirectory: String) {
 
     fun runTestSession(
             adbDevice: AdbDevice,
@@ -18,10 +18,11 @@ class TestRunFactory {
             logcatFileIO: LogcatFileIO = LogcatFileIO(
                     adbDevice = adbDevice,
                     timeoutSeconds = args.chunkTimeoutSeconds.toInt(),
-                    outputDirPath = args.outputDirectory
+                    outputDirPath = "$workingDirectory/${args.outputDirectory}",
+                    verboseOutput = true,
             ),
             logcatRecorder: LogcatRecorder = LogcatRecorder(adbDevice, logcatFileIO),
-            installer: Installer = Installer(adbDevice),
+            installer: Installer = Installer(adbDevice = adbDevice, verboseOutput = args.verboseOutput),
             filePuller: FilePuller = FilePuller(adbDevice),
             testChunkRunner: TestChunkRunner = TestChunkRunner(args, adbDevice, logcatFileIO, installer),
             testChunkRetryer: TestChunkRetryer = TestChunkRetryer(adbDevice, args, logcatFileIO, testChunkRunner, installer)

--- a/torque-core/src/main/kotlin/com/workday/torque/Torque.kt
+++ b/torque-core/src/main/kotlin/com/workday/torque/Torque.kt
@@ -6,11 +6,14 @@ import io.reactivex.Single
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-class Torque(private val args: Args,
-             private val moduleTestParser: ModuleTestParser = ModuleTestParser(args),
-             private val adbDeviceFinder: AdbDeviceFinder = AdbDeviceFinder(),
-             private val testRunFactory: TestRunFactory = TestRunFactory(),
-             private val resultWriter: ResultWriter = ResultWriter(args)) {
+class Torque(
+    private val args: Args,
+    private val workingDirectory: String,
+    private val moduleTestParser: ModuleTestParser = ModuleTestParser(args),
+    private val adbDeviceFinder: AdbDeviceFinder = AdbDeviceFinder(),
+    private val testRunFactory: TestRunFactory = TestRunFactory(workingDirectory),
+    private val resultWriter: ResultWriter = ResultWriter(args, workingDirectory),
+) {
 
     fun run() {
         val startTime = System.currentTimeMillis()

--- a/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/TestRunFactorySpec.kt
@@ -15,9 +15,11 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import java.nio.file.Paths
 
 class TestRunFactorySpec : Spek(
 {
+    val workingDirectory = Paths.get("./").toAbsolutePath().toString()
     context("Run test chunk") {
         val adbDevice = AdbDevice("id", "model", online = true)
         val logcatFileIO = mockk<LogcatFileIO>(relaxed = true)
@@ -52,7 +54,7 @@ class TestRunFactorySpec : Spek(
                 val args = Args().apply {
                     appApkPath = "somePath"
                 }
-                TestRunFactory().runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
+                TestRunFactory(workingDirectory).runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
                         .test()
                         .await()
 
@@ -80,7 +82,7 @@ class TestRunFactorySpec : Spek(
                         testFilesPullDeviceDirectory = "somePath"
                         testFilesPullHostDirectory = "somePath"
                     }
-                    TestRunFactory().runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
+                    TestRunFactory(workingDirectory).runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
                             .test()
                             .await()
 
@@ -96,7 +98,7 @@ class TestRunFactorySpec : Spek(
                         appApkPath = "somePath"
                     }
 
-                    TestRunFactory().runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
+                    TestRunFactory(workingDirectory).runTestSession(adbDevice, args, testPool, logcatFileIO, logcatRecorder, installer, filePuller, testChunkRunner, chunkRetryer)
                             .test()
                             .await()
 

--- a/torque-core/src/test/kotlin/com/workday/torque/TorqueSpec.kt
+++ b/torque-core/src/test/kotlin/com/workday/torque/TorqueSpec.kt
@@ -8,10 +8,13 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import java.nio.file.Paths
 import kotlin.test.assertFailsWith
 
 class TorqueSpec : Spek (
 {
+    val currentDir = Paths.get("./").toAbsolutePath().toString()
+
     context("Run Torque") {
         val args = Args()
         val moduleTestParser = mockk<ModuleTestParser> {
@@ -31,7 +34,7 @@ class TorqueSpec : Spek (
         val resultWriter = mockk<ResultWriter>(relaxed = true)
 
         given("completed test sessions") {
-            val torque = Torque(args, moduleTestParser, adbDeviceFinder, testRunFactory, resultWriter)
+            val torque = Torque(args, currentDir, moduleTestParser, adbDeviceFinder, testRunFactory, resultWriter,)
             it("Parses tests from apks and starts TestRuns on connectedDevices and writes the results") {
                 torque.run()
 
@@ -50,7 +53,7 @@ class TorqueSpec : Spek (
             val failedModuleTestParser = mockk<ModuleTestParser> {
                 every { parseTestsFromModuleApks() } throws IllegalStateException("apk parse error")
             }
-            val torque = Torque(args, failedModuleTestParser, adbDeviceFinder, testRunFactory, resultWriter)
+            val torque = Torque(args, currentDir, failedModuleTestParser, adbDeviceFinder, testRunFactory, resultWriter,)
             it("passes that exception to the caller") {
                 assertFailsWith(IllegalStateException::class, "apk parse error") {
                     torque.run()
@@ -62,7 +65,7 @@ class TorqueSpec : Spek (
             val failedAdbDeviceFinder = mockk<AdbDeviceFinder> {
                 every { onlineAdbDevices() } throws IllegalStateException("Error: No devices available for tests.")
             }
-            val torque = Torque(args, moduleTestParser, failedAdbDeviceFinder, testRunFactory, resultWriter)
+            val torque = Torque(args, currentDir, moduleTestParser, failedAdbDeviceFinder, testRunFactory, resultWriter,)
             it("passes that exception to the caller") {
                 assertFailsWith(IllegalStateException::class, "Error: No devices available for tests.") {
                     torque.run()
@@ -74,7 +77,7 @@ class TorqueSpec : Spek (
             val failedResultWriter = mockk<ResultWriter>(relaxed = true) {
                 every { write(any(), any()) } throws IllegalStateException("Error: 0 tests were run.")
             }
-            val torque = Torque(args, moduleTestParser, adbDeviceFinder, testRunFactory, failedResultWriter)
+            val torque = Torque(args, currentDir, moduleTestParser, adbDeviceFinder, testRunFactory, failedResultWriter,)
             it("passes that exception to the caller") {
                 assertFailsWith(IllegalStateException::class, "Error: 0 tests were run.") {
                     torque.run()

--- a/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
+++ b/torque-gradle-plugin/src/main/kotlin/com/workday/torque/gradle/TorquePlugin.kt
@@ -87,8 +87,11 @@ class TorquePlugin : Plugin<Project> {
 
     private fun configureTaskOptionsAndRun(torqueArgs: Args, task: TorqueRunTask) {
         torqueArgs.configureTaskOptions(task)
-        println("Starting Torque run with args: $torqueArgs")
-        Torque(torqueArgs).run()
+        if (torqueArgs.verboseOutput) {
+            println("Starting Torque run with args: $torqueArgs")
+        }
+        val rootDir = task.project.rootDir.toString()
+        Torque(args = torqueArgs, workingDirectory = rootDir).run()
     }
 
     private fun Args.configureTaskOptions(task: TorqueRunTask) {

--- a/torque-runner/src/main/kotlin/com/workday/torque/Main.kt
+++ b/torque-runner/src/main/kotlin/com/workday/torque/Main.kt
@@ -1,14 +1,16 @@
 package com.workday.torque
 
+import java.nio.file.Paths
 import kotlin.system.exitProcess
 
 private val PARAMETER_HELP_NAMES = setOf("--help", "-help", "help", "-h")
 
 fun main(rawArgs: Array<String>) {
+    val currentDirectoryPath = Paths.get("./").toAbsolutePath()
     val args = parseProcessArgs(rawArgs)
-    Torque(args).run()
+    Torque(args = args, workingDirectory = currentDirectoryPath.toString()).run()
 
-    System.exit(0)
+    exitProcess(0)
 }
 
 private fun parseProcessArgs(rawArgs: Array<String>): Args {


### PR DESCRIPTION
It seems AGP 7 has changed the working/running directory context when executing torque, running it from ~/.gradle/7.0.2/daemon instead of the expected location.

This work fixes that behavior, and adjusts output buffering for reliability.